### PR TITLE
 WIP/ Move to parent-child relation chain

### DIFF
--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/AppliedMigrations.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/AppliedMigrations.scala
@@ -1,8 +1,3 @@
 package dk.cwconsult.peregrin.core
 
-case class AppliedMigrations(migrations: Vector[Migration]) {
-
-  def count: Int =
-    migrations.size
-
-}
+case class AppliedMigrations(count: Int)

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/ImpossibleChangeLogMigrationException.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/ImpossibleChangeLogMigrationException.scala
@@ -1,0 +1,6 @@
+package dk.cwconsult.peregrin.core
+
+class ImpossibleChangeLogMigrationException(
+  message: String,
+  throwable: Throwable = null)
+  extends MigrationException(message, throwable)

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/InconsistentMigrationIdDeclarationsException.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/InconsistentMigrationIdDeclarationsException.scala
@@ -1,0 +1,6 @@
+package dk.cwconsult.peregrin.core
+
+class InconsistentMigrationIdDeclarationsException(
+  message: String,
+  throwable: Throwable = null)
+  extends MigrationException(message, throwable)

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/InvalidChangeLogVersionException.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/InvalidChangeLogVersionException.scala
@@ -1,0 +1,6 @@
+package dk.cwconsult.peregrin.core
+
+class InvalidChangeLogVersionException(
+  message: String,
+  throwable: Throwable = null)
+  extends MigrationException(message, throwable)

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/Migration.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/Migration.scala
@@ -1,8 +1,63 @@
 package dk.cwconsult.peregrin.core
 
+import java.util.UUID
+
+import dk.cwconsult.peregrin.core.migrations.MigrationId
+import dk.cwconsult.peregrin.core.migrations.MigrationId.ChildParentRelation
+import dk.cwconsult.peregrin.core.migrations.MigrationId.LegacyId
+
 /**
  * Migration step.
  */
-case class Migration(
-  identifier: Int,
-  sql: String)
+sealed trait Migration {
+
+  def identifier: MigrationId
+
+  def legacyIdentifier: Option[LegacyId]
+
+  def sql: String
+
+}
+
+object Migration {
+
+  case class MigrationV1(
+    override val identifier: LegacyId,
+    override val sql: String) extends Migration {
+    override val legacyIdentifier: Option[LegacyId] = Some(identifier)
+  }
+
+  case class MigrationV2(
+    legacyId: LegacyId,
+    override val identifier: ChildParentRelation,
+    override val sql: String) extends Migration {
+    override val legacyIdentifier: Option[LegacyId] = Some(legacyId)
+  }
+
+  case class MigrationV3(
+    override val identifier: ChildParentRelation,
+    override val sql: String) extends Migration {
+    override val legacyIdentifier: Option[LegacyId] = None
+  }
+
+  def apply(identifier: Int, sql: String): Migration =
+    MigrationV1(
+      identifier = LegacyId(identifier),
+      sql = sql)
+
+  def apply(uuid: UUID, parentId: Option[UUID], sql: String): Migration =
+    MigrationV3(
+      identifier = MigrationId.ChildParentRelation(
+        id = uuid,
+        parentId = parentId),
+      sql = sql)
+
+  def apply(legacyIdentifier: Int, uuid: UUID, parentId: Option[UUID], sql: String): Migration =
+    MigrationV2(
+      legacyId = LegacyId(legacyIdentifier),
+      identifier = ChildParentRelation(
+        id = uuid,
+        parentId = parentId),
+      sql = sql)
+
+}

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/Migrations.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/Migrations.scala
@@ -8,6 +8,8 @@ object Migrations {
 
   /**
     * Apply a list of migrations to the given database schema.
+    *
+    * Must all be of the same Migration definition format.
     */
   def applyMigrations(connection: Connection, schema: Schema, migrations: Seq[Migration]): AppliedMigrations = {
     new MigrationsImpl(connection, schema).applyChangeLog(migrations.toVector)

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/UnresolvedChangeLogEntriesFoundException.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/UnresolvedChangeLogEntriesFoundException.scala
@@ -1,0 +1,6 @@
+package dk.cwconsult.peregrin.core
+
+class UnresolvedChangeLogEntriesFoundException(
+  message: String,
+  throwable: Throwable = null)
+  extends MigrationException(message, throwable)

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/ChangeLogEntry.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/ChangeLogEntry.scala
@@ -1,5 +1,24 @@
 package dk.cwconsult.peregrin.core.impl
 
+import java.util.UUID
+
 private[impl] case class ChangeLogEntry(
-  identifier: Int,
+  legacyIdentifier: Int,
+  migrationId: Option[UUID],
+  migrationParentId: Option[UUID],
   sql: String)
+
+object ChangeLogEntry {
+
+  sealed abstract class ChangeLogVersion(
+    val versionInt: Int)
+
+  object ChangeLogVersion {
+
+    case object V1 extends ChangeLogVersion(1)
+    case object V2 extends ChangeLogVersion(2)
+    case object V3 extends ChangeLogVersion(3)
+
+  }
+
+}

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/ChangeLogIdentity.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/ChangeLogIdentity.scala
@@ -1,0 +1,27 @@
+package dk.cwconsult.peregrin.core.impl
+
+import dk.cwconsult.peregrin.core.Migration
+import dk.cwconsult.peregrin.core.Migration.MigrationV1
+import dk.cwconsult.peregrin.core.Migration.MigrationV2
+import dk.cwconsult.peregrin.core.Migration.MigrationV3
+
+object ChangeLogIdentity {
+
+  def correspondsTo(m: Migration, changeLogEntryRow: ChangeLogEntry): Boolean =
+    m match {
+
+      case v1: MigrationV1 =>
+        v1.identifier.legacyId == changeLogEntryRow.legacyIdentifier
+
+      case v2: MigrationV2 =>
+        v2.legacyId.legacyId == changeLogEntryRow.legacyIdentifier || (
+          changeLogEntryRow.migrationId.contains(v2.identifier.id) &&
+          changeLogEntryRow.migrationParentId == v2.identifier.parentId)
+
+      case v3: MigrationV3 =>
+        changeLogEntryRow.migrationId.contains(v3.identifier.id) &&
+        changeLogEntryRow.migrationParentId == v3.identifier.parentId
+
+    }
+
+}

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/ChangeLogResolver.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/ChangeLogResolver.scala
@@ -1,0 +1,32 @@
+package dk.cwconsult.peregrin.core.impl
+
+import dk.cwconsult.peregrin.core.Migration
+
+object ChangeLogResolver {
+
+  case class ChangeLogEntries(
+    unresolvedEntries: Seq[ChangeLogEntry],
+    migrationsWithEntries: Seq[(Migration, Option[ChangeLogEntry])])
+
+  def resolveChangeLogEntries(
+    migrations: Seq[Migration],
+    changeLogEntries: Seq[ChangeLogEntry]
+  ): ChangeLogEntries = {
+    // Perform mapping
+    val mappings =
+      for (migration <- migrations) yield {
+        val maybeMatchingChangeLog =
+          changeLogEntries.find(
+            ChangeLogIdentity.correspondsTo(migration, _))
+        (migration, maybeMatchingChangeLog)
+      }
+    // Resolve changelog entries that were not resolved
+    val unresolved =
+      changeLogEntries.filterNot(e => mappings.exists(_._2.contains(e)))
+    // Return result
+    ChangeLogEntries(
+      unresolvedEntries = unresolved,
+      migrationsWithEntries = mappings)
+  }
+
+}

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/MigrateChangeLogEntry.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/MigrateChangeLogEntry.scala
@@ -1,0 +1,78 @@
+package dk.cwconsult.peregrin.core.impl
+
+import dk.cwconsult.peregrin.core.Migration
+import dk.cwconsult.peregrin.core.Migration.MigrationV1
+import dk.cwconsult.peregrin.core.Migration.MigrationV2
+import dk.cwconsult.peregrin.core.Migration.MigrationV3
+import dk.cwconsult.peregrin.core.impl.ChangeLogEntry.ChangeLogVersion
+
+/**
+  * Migrate a given ChangeLogEntry to the used Migration version.
+  *
+  * In down-grade scenarios, new information is augmented to the
+  * entry, but the version identifier will not be decremented.
+  *
+  * This means, that a migration from V3 to V1 is possible, as long
+  * as V2 is used as an intermediate step. But the entry in the
+  * change log, will still declare itself as a V3 compatible entry.
+  */
+object MigrateChangeLogEntry {
+
+  private[this] def migrateChangeLog(version: ChangeLogVersion, changeLogEntry: ChangeLogEntry, migration: MigrationV1): Either[String, ChangeLogEntry] =
+    // Do nothing
+    version match {
+      case ChangeLogVersion.V1 =>
+        // Already at expected version
+        Right(changeLogEntry)
+      case ChangeLogVersion.V2 =>
+        // No migration needed, preserve version
+        Right(changeLogEntry)
+      case ChangeLogVersion.V3 =>
+        if (changeLogEntry.legacyIdentifier != -1) {
+          Right(changeLogEntry)
+        } else {
+          Left(s"Unable to migrate from V3 to V1 directly")
+        }
+    }
+
+  private[this] def migrateChangeLog(version: ChangeLogVersion,changeLogEntry: ChangeLogEntry, migration: MigrationV2): Either[String, ChangeLogEntry] =
+    version match {
+      case ChangeLogVersion.V1 =>
+        // Migrate from version 1 to 2
+        Right(changeLogEntry.copy(
+          migrationId = Some(migration.identifier.id),
+          migrationParentId = migration.identifier.parentId))
+      case ChangeLogVersion.V2 =>
+        // No migration needed, already expected version
+        Right(changeLogEntry)
+      case ChangeLogVersion.V3 =>
+        // Add new information, but preserve version,
+        // allowing further downgrade to V1
+        Right(changeLogEntry.copy(
+          legacyIdentifier = migration.legacyId.legacyId))
+    }
+
+  private[this] def migrateChangeLog(version: ChangeLogVersion, changeLogEntry: ChangeLogEntry, migration: MigrationV3): Either[String, ChangeLogEntry] =
+    version match {
+      case ChangeLogVersion.V1 =>
+        Left(s"Unable to migrate from V1 to V3 directly")
+      case ChangeLogVersion.V2 =>
+        // V3 only drops information of old id
+        Right(changeLogEntry)
+      case ChangeLogVersion.V3 =>
+        // No migration needed, already at expected version
+        Right(changeLogEntry)
+    }
+
+  def migrateChangeLogEntry(
+    version: ChangeLogVersion,
+    changeLogEntry: ChangeLogEntry,
+    migration: Migration
+  ): Either[String, ChangeLogEntry] =
+    migration match {
+      case v: MigrationV1 => migrateChangeLog(version, changeLogEntry, v)
+      case v: MigrationV2 => migrateChangeLog(version, changeLogEntry, v)
+      case v: MigrationV3 => migrateChangeLog(version, changeLogEntry, v)
+    }
+
+}

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/MigrationOrdering.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/MigrationOrdering.scala
@@ -1,0 +1,112 @@
+package dk.cwconsult.peregrin.core.impl
+
+import java.util.UUID
+
+import dk.cwconsult.peregrin.core.InvalidMigrationSequenceException
+import dk.cwconsult.peregrin.core.Migration
+import dk.cwconsult.peregrin.core.migrations.MigrationId.LegacyId
+import dk.cwconsult.peregrin.core.migrations.MigrationId.ChildParentRelation
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+object MigrationOrdering {
+
+  def orderByLegacyId(allMigrations: Vector[Migration]): Either[String, Vector[Migration]] = {
+    // Extract integer legacy id for ordering
+    val migrationsWithLegacyIds: Vector[Option[(LegacyId, Migration)]] =
+      allMigrations.map { m =>
+        m.legacyIdentifier.map { legacyId =>
+          (legacyId, m)
+        }
+      }
+    // Split migrations based on declaration of legacy ids
+    val (missingLegacyIds, hasLegacyIds) =
+      migrationsWithLegacyIds.partition(_.isEmpty)
+    // Sort the migrations, if all have a legacy id
+    if (missingLegacyIds.nonEmpty) {
+      Left(
+        "The following Migration(s) are lacking a legacy Integer-identifier: "+
+        missingLegacyIds.mkString(", "))
+    } else {
+      Right(hasLegacyIds.flatten.sortBy(_._1.legacyId).map(_._2))
+    }
+  }
+
+  case class UuidMigration(
+    uuidId: ChildParentRelation,
+    migration: Migration
+  )
+
+  private[this] def tsort(migrations: Vector[UuidMigration]): Vector[Migration] = {
+    // Build lookup table by Parent Id
+    val migrationsByParent: mutable.Map[Option[UUID], Vector[UuidMigration]] =
+      mutable.Map.empty ++ migrations.groupBy(_.uuidId.parentId)
+    // Prepare queue for discovered migrations
+    val discoveredMigrations: mutable.Queue[UuidMigration] =
+      new mutable.Queue[UuidMigration]()
+
+    def queueWithParent(parentId: Option[UUID]): Unit = {
+      discoveredMigrations ++= migrationsByParent.remove(parentId).getOrElse(Vector.empty)
+    }
+
+    // Prepare result, topologically sorted migrations
+    val result: ArrayBuffer[Migration] = new ArrayBuffer[Migration]()
+
+    // Sanity check, that we have at least one root node
+    if (!migrationsByParent.contains(None) && migrationsByParent.nonEmpty) {
+      throw new InvalidMigrationSequenceException(
+        s"Migration sequence MUST contain at least one root node (no parent)")
+    }
+
+    // Queue all root nodes first
+    queueWithParent(None)
+    // While we have referenced migrations, build the result
+    while (discoveredMigrations.nonEmpty) {
+      // Get a migration from the queue
+      val m = discoveredMigrations.dequeue()
+      // Queue all migrations that has this migration as a parent
+      queueWithParent(Some(m.uuidId.id))
+      // Add current migration to the output
+      result += m.migration
+    }
+
+    // Sanity check, that all migrations have been identified
+    if (migrationsByParent.nonEmpty) {
+      throw new InvalidMigrationSequenceException(
+        s"Migrations MUST reference valid parents (Do you have a cycle?). The following Migrations referenced unknown parents: "+
+        migrationsByParent.values.toVector.flatMap(_.map(_.uuidId.id)))
+    }
+
+    result.toVector
+  }
+
+  def orderByParentReferences(allMigrations: Vector[Migration]): Either[Int, Vector[Migration]] = {
+    // Extract UUID based id for ordering
+    val migrationsWithUUID: Vector[Option[UuidMigration]] =
+      allMigrations.map {
+        case _: Migration.MigrationV1 =>
+          None
+        case m: Migration.MigrationV2 =>
+          Some(UuidMigration(
+            uuidId = m.identifier,
+            migration = m))
+        case m: Migration.MigrationV3 =>
+          Some(UuidMigration(
+            uuidId = m.identifier,
+            migration = m))
+      }
+    // Split migrations based on declaration of parent ids
+    val (missingUuid, hasUuid) =
+      migrationsWithUUID.partition(_.isEmpty)
+    // Sort the migrations, if we have UUIDs declared for all
+    if (missingUuid.nonEmpty) {
+      // Return number of migrations missing uuid identifier,
+      // if it is not all, an error should be raised
+      Left(missingUuid.size)
+    } else {
+      Right(tsort(hasUuid.flatten))
+    }
+  }
+
+}

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/MigrationsImpl.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/MigrationsImpl.scala
@@ -2,76 +2,39 @@ package dk.cwconsult.peregrin.core.impl
 
 import java.sql.Connection
 
+import dk.cwconsult.peregrin.core.AppliedMigrations
 import dk.cwconsult.peregrin.core.DisjointMigrationsException
+import dk.cwconsult.peregrin.core.ImpossibleChangeLogMigrationException
+import dk.cwconsult.peregrin.core.InvalidMigrationSequenceException
 import dk.cwconsult.peregrin.core.Migration
 import dk.cwconsult.peregrin.core.MigrationModifiedException
-import dk.cwconsult.peregrin.core.AppliedMigrations
-import dk.cwconsult.peregrin.core.InvalidMigrationSequenceException
 import dk.cwconsult.peregrin.core.Schema
-import dk.cwconsult.peregrin.core.Table
+import dk.cwconsult.peregrin.core.UnresolvedChangeLogEntriesFoundException
+import dk.cwconsult.peregrin.core.impl.ChangeLogEntry.ChangeLogVersion
 import dk.cwconsult.peregrin.core.impl.ConnectionImplicits._
-
-import scala.collection.mutable.ArrayBuffer
+import dk.cwconsult.peregrin.core.impl.dao.ChangeLogDAO
+import dk.cwconsult.peregrin.core.impl.dao.ChangeLogDAOImpl
+import dk.cwconsult.peregrin.core.impl.dao.ChangeLogMetaDataDAO
+import dk.cwconsult.peregrin.core.impl.dao.ChangeLogMetaDataDAOImpl
 
 /**
  * Main class for performing migrations.
  */
 private[peregrin] class MigrationsImpl(connection: Connection, schema: Schema) {
 
-  private[this] val changeLogTable =
-    Table(
-      name = "__peregrin_changelog__",
-      schema)
 
-  /**
-    * Create change log if necessary.
-    */
-  private[this] def createChangeLogIfMissing(): Unit = {
-    // Create the schema if necessary.
-    connection.execute(s"CREATE SCHEMA IF NOT EXISTS $schema")
-    // Create the migration log table.
-    val _ = connection.execute(s"""
-        CREATE TABLE IF NOT EXISTS $changeLogTable (
-          "identifier" INT NOT NULL,
-          "sql" TEXT NOT NULL,
-          "executed" TIMESTAMP WITH TIME ZONE NOT NULL)
-      """)
-  }
+  private[this] val changeLogTableDAO: ChangeLogDAO =
+    new ChangeLogDAOImpl(schema, connection)
 
-  /**
-    * Read a changelog.
-    */
-  private[this] def readChangeLogEntries(): Vector[ChangeLogEntry] = {
-    connection.executeQuery(s"""SELECT "identifier", "sql" FROM $changeLogTable ORDER BY "identifier" ASC""") { resultSet =>
-      // Extract all the results
-      val rows = new ArrayBuffer[ChangeLogEntry]()
-      while (resultSet.next()) {
-        rows += ChangeLogEntry(
-          identifier = resultSet.getInt(1),
-          sql = resultSet.getString(2))
-      }
-      rows.toVector
-    }
-  }
-
-  private[this] def insertChangeLogEntry(changeLogEntry: ChangeLogEntry): Unit = {
-    // Insert the entry.
-    val insertCount = connection.executeUpdatePrepared(s"""INSERT INTO $changeLogTable ("identifier", "sql", "executed") VALUES (?, ?, now())""") { stmt =>
-      stmt.setInt(1, changeLogEntry.identifier)
-      stmt.setString(2, changeLogEntry.sql)
-    }
-    // Sanity check: Must have inserted exactly one row.
-    if (insertCount != 1) {
-      throw new IllegalStateException(s"Internal consistency error: No rows inserted")
-    }
-  }
+  private[this] val changeLogMetaDataDAO: ChangeLogMetaDataDAO =
+    new ChangeLogMetaDataDAOImpl(schema, connection)
 
   private[this] def applyMigration(changeLogEntry: ChangeLogEntry): ChangeLogEntry = {
     // Perform the migration. We assume that all statements are "updates", i.e.
     // either UPDATE/INSERT/etc. or DDL statements.
     connection.executeUpdate(changeLogEntry.sql)
     // Insert the change log entry.
-    insertChangeLogEntry(changeLogEntry)
+    changeLogTableDAO.insertChangeLogEntry(changeLogEntry)
     // Return applied changeLogEntry
     changeLogEntry
   }
@@ -102,47 +65,126 @@ private[peregrin] class MigrationsImpl(connection: Connection, schema: Schema) {
     * list of migrations that have yet to be performed.
     */
   private[this] def verifyChangeLogEntries(migrations: Vector[Migration]): Vector[ChangeLogEntry] = {
-    // Compute map all the migrations to ChangeLogEntry so that we have
-    // checksums, etc. to compare against.
-    val inputChangeLogEntries = migrations.map { migration =>
-      ChangeLogEntry(
-        identifier = migration.identifier,
-        sql = migration.sql)
-    }
     // Load up all the existing change log
-    val existingChangeLogEntries = readChangeLogEntries()
-    // Make sure existing entries match. Our assumption here
-    // is that the given input migrations are in sorted order
-    // and start at "identifier == 1".
-    for (correspondingChangeLogEntries <- existingChangeLogEntries.zip(inputChangeLogEntries)) {
-      val existingChangeLogEntry = correspondingChangeLogEntries._1
-      val inputChangeLogEntry = correspondingChangeLogEntries._2
-      // Check that the SQL matches. We need to explicitly trim existing
-      // SQL entries since they may have been inserted before we started
-      // trimming input migration SQL.
-      if (trimSql(existingChangeLogEntry.sql) != inputChangeLogEntry.sql) {
-        throwDoesNotMatch(
-          existingSql = existingChangeLogEntry.sql,
-          newSql = inputChangeLogEntry.sql)
+    val existingChangeLogEntries =
+      changeLogTableDAO.readChangeLogEntries()
+
+    // Read existing change log version
+    val version: ChangeLogVersion =
+      changeLogMetaDataDAO.readChangeLogVersionOrDefault()
+
+    // Next changelog version, after upcasting.
+    val versionsInMigrations =
+      migrations.map {
+        case _: Migration.MigrationV1 => ChangeLogVersion.V1
+        case _: Migration.MigrationV2 => ChangeLogVersion.V2
+        case _: Migration.MigrationV3 => ChangeLogVersion.V3
+      }
+      .distinct
+
+    if (versionsInMigrations.size > 1) {
+      throw new InvalidMigrationSequenceException("All migrations MUST be of the same version")
+    }
+
+    val maybeNextVersion: Option[ChangeLogVersion] =
+      versionsInMigrations.headOption
+
+    // Resolve input migrations with existing changelog entries
+    val entries =
+      ChangeLogResolver.resolveChangeLogEntries(
+        migrations = migrations,
+        changeLogEntries = existingChangeLogEntries)
+
+    // Ensure we do not have any unresolved entries. That could indicate
+    // an invalid progression through migration formats, so we disallow it.
+    if (entries.unresolvedEntries.nonEmpty) {
+      throw new UnresolvedChangeLogEntriesFoundException(
+        "The provided list of migrations MUST include all known change log entries. "+
+        s"The following entries were found in the DB, and were unresolvable: ${entries.unresolvedEntries.mkString(",")}")
+    }
+
+    // Make sure existing entries match.
+    for (correspondingChangeLogEntries <- entries.migrationsWithEntries) {
+      val maybeExistingChangeLogEntry = correspondingChangeLogEntries._2
+      maybeExistingChangeLogEntry foreach { existingChangeLogEntry =>
+        val inputMigration = correspondingChangeLogEntries._1
+        // Check that the SQL matches. We need to explicitly trim existing
+        // SQL entries since they may have been inserted before we started
+        // trimming input migration SQL.
+        if (trimSql(existingChangeLogEntry.sql) != inputMigration.sql) {
+          throwDoesNotMatch(
+            existingSql = existingChangeLogEntry.sql,
+            newSql = inputMigration.sql)
+        }
       }
     }
+
+    // Determine which Change Log entries need to be migrated to new version,
+    // and collect the new migrated entries
+    val entriesForUpdate: Seq[Option[(ChangeLogEntry, ChangeLogEntry)]] =
+      for (correspondingEntries <- entries.migrationsWithEntries) yield {
+        correspondingEntries._2 flatMap { existingChangeLogEntry =>
+          val inputMigration = correspondingEntries._1
+          MigrateChangeLogEntry.migrateChangeLogEntry(
+            version = version,
+            changeLogEntry = existingChangeLogEntry,
+            migration = inputMigration
+          ) match {
+            case Left(error) =>
+              throw new ImpossibleChangeLogMigrationException(
+                s"Unable to migrate $existingChangeLogEntry. Error: $error")
+            case Right(migratedChangeLogEntry) =>
+              if (migratedChangeLogEntry != existingChangeLogEntry) {
+                Some((migratedChangeLogEntry, existingChangeLogEntry))
+              } else {
+                None
+              }
+          }
+        }
+      }
+
+    // Perform update in changelog table, we do this after, to ensure
+    // we were able to migrate all entries, before updating the first
+    for (entry <- entriesForUpdate.flatten) {
+      val migrated = entry._1
+      val existing = entry._2
+      changeLogTableDAO.updateChangeLogEntry(migrated, existing)
+    }
+
+    // All updates performed, if any. Write new version information
+    // to changelog metadata table.
+    maybeNextVersion match {
+      case Some(next) if next.versionInt > version.versionInt =>
+        changeLogMetaDataDAO.writeChangeLogVersion(next)
+      case _ =>
+        // Either nothing to do, or a downgrade, which we wont write,
+        // we don't throwaway information, so the changelogs are still valid
+        ()
+    }
+
     // Everything matches up to the list of existing entries,
     // so we just need to apply the remainder; we can get that
-    // by just dropping the prefix (i.e. the existing entries).
-    inputChangeLogEntries.drop(existingChangeLogEntries.size)
-  }
-
-  /**
-    * Run the given block in with a (transactional) lock.
-    */
-  private[this] def withChangeLogLock[A](block: => A): A = {
-    connection.execute(s"LOCK $changeLogTable IN EXCLUSIVE MODE")
-    try {
-      block
-    } finally {
-      // Nothing to do; the lock will automatically be released at the end
-      // of the transaction.
-    }
+    // by finding the migrations without associated changelog entries
+    entries.migrationsWithEntries
+      .filter(_._2.isEmpty)
+      .toVector
+      .map { pair =>
+        val migration = pair._1
+        val (maybeId, maybeParent) =
+          migration match {
+            case _: Migration.MigrationV1 =>
+              (None, None)
+            case m: Migration.MigrationV2 =>
+              (Some(m.identifier.id), m.identifier.parentId)
+            case m: Migration.MigrationV3 =>
+              (Some(m.identifier.id), m.identifier.parentId)
+          }
+        ChangeLogEntry(
+          legacyIdentifier = migration.legacyIdentifier.map(_.legacyId).getOrElse(-1),
+          migrationId = maybeId,
+          migrationParentId = maybeParent,
+          sql = migration.sql)
+      }
   }
 
   /**
@@ -150,13 +192,20 @@ private[peregrin] class MigrationsImpl(connection: Connection, schema: Schema) {
     * list is sorted by identifier.
     */
   private[this] def isContiguous(migrations: Vector[Migration]): Boolean = {
+    // Get migrations with a legacy identifier
+    val migrationIds =
+      migrations
+        .flatMap(_.legacyIdentifier)
+        .map(_.legacyId)
     // Expected identifiers are [0..]
-    val expectedIdentifiers = 0 until migrations.length
+    val expectedIdentifiers = 0 until migrationIds.length
     // Check each migration against its expected index.
-    migrations.zip(expectedIdentifiers).forall {
-      case (migration, expectedIdentifier) =>
-        migration.identifier == expectedIdentifier
-    }
+    migrationIds
+      .zip(expectedIdentifiers)
+      .forall {
+        case (migrationIdentifier, expectedIdentifier) =>
+          migrationIdentifier == expectedIdentifier
+      }
   }
 
   /**
@@ -166,24 +215,27 @@ private[peregrin] class MigrationsImpl(connection: Connection, schema: Schema) {
     * over multiple calls to [[applyChangeLog()]] (as opposed to doing it
     * in a single call -- which is the case this is meant for handling).
     *
-    * We assume that the input list is sorted by identifier.
+    * We assume that the input list is sorted.
     */
   private[this] def removeDuplicates(migrations: Vector[Migration]): Vector[Migration] = {
-    // Check that all adjacent "duplicates" are in fact identical. By the
-    // "sorted" property we know that all duplicates will be adjacent, and
-    // by the transitive property of equality we know that once we're through
+    // Check that all "duplicates" are in fact identical. We group all migrations
+    // with identical identifiers, and iterate through all migrations with identical
+    // identifiers and compare the SQL, so that we know that once we're through
     // this loop *all* migrations with a given identifier must have identical
     // SQL.
-    migrations.zip(migrations.drop(1)).foreach {
-      case (existingMigration, newMigration) =>
-        if (existingMigration.identifier == newMigration.identifier) {
-          if (existingMigration.sql != newMigration.sql) {
-            throwDoesNotMatch(
-              existingSql = existingMigration.sql,
-              newSql = newMigration.sql)
-          }
+    migrations
+      .groupBy(_.identifier)
+      .filter(_._2.size > 1)
+      .foreach { kv =>
+        val differentSqls =
+          kv._2.map(_.sql).distinct
+        if (differentSqls.length > 1) {
+          throwDoesNotMatch(
+            existingSql = differentSqls.headOption.getOrElse(""),
+            newSql = differentSqls.lift(1).getOrElse(""))
         }
-    }
+      }
+
     // Remove the duplicates.
     migrations.distinct
   }
@@ -193,21 +245,62 @@ private[peregrin] class MigrationsImpl(connection: Connection, schema: Schema) {
    */
   def applyChangeLog(_migrations: Vector[Migration]): AppliedMigrations = {
     // Trim all input SQL.
-    val trimmedMigrations = _migrations.map(m => m.copy(sql = trimSql(m.sql)))
+    val trimmedMigrations = _migrations.map {
+      case m: Migration.MigrationV1 => m.copy(sql = trimSql(m.sql))
+      case m: Migration.MigrationV2 => m.copy(sql = trimSql(m.sql))
+      case m: Migration.MigrationV3 => m.copy(sql = trimSql(m.sql))
+    }
+
+    // Order the given migrations. We first attempt to order them
+    // based on the legacy integer id, and secondly using the declared
+    // parent chain. If both are available, we ensure they produce the
+    // same ordering, before we continue.
+
+    val orderedByLegacyId =
+      MigrationOrdering.orderByLegacyId(trimmedMigrations)
+    val orderedByParentRef =
+      MigrationOrdering.orderByParentReferences(trimmedMigrations)
+
     // Sanitize input
-    val allMigrations = removeDuplicates(trimmedMigrations
-      // Make sure the migrations are in sorted order.
-      .sortBy(_.identifier))
+    val allMigrations: Vector[Migration] =
+      (orderedByLegacyId, orderedByParentRef) match {
+        case (Left(err), Left(_)) =>
+          throw new InvalidMigrationSequenceException(
+            s"Provided migrations MUST have a common identifier type defined: $err")
+        case (Right(sortedByLegacyId), Right(sortedByRef)) =>
+          if (sortedByLegacyId == sortedByRef) {
+            sortedByRef
+          } else {
+            throw new InvalidMigrationSequenceException(
+              s"Provided migrations MUST have the SAME ordering, when both Legacy Id and Parent Id provided")
+          }
+        case (Left(_), Right(sortedByRef)) =>
+          // This case: Only if existing migrations have UUID refs stamped in DB?
+          sortedByRef
+        case (Right(sortedByLegacyId), Left(numUnresolved)) =>
+          if (sortedByLegacyId.length != numUnresolved) {
+            throw new InvalidMigrationSequenceException(
+              s"If some migrations are given a UUID identifier, ALL MUST be given a UUID identifier")
+          } else {
+            sortedByLegacyId
+          }
+      }
+
+    // Remove duplicates
+    val deduplicatedMigrations = removeDuplicates(allMigrations)
+
+    // Make sure nothing changed with duplicate-removal, and sorting
+    if (allMigrations != deduplicatedMigrations) {
+      throw new InvalidMigrationSequenceException(
+        s"Provided migrations MUST be ordered by identifier, and contain no duplicates")
+    }
+
     // Make sure that all the identifiers are contiguous.
     if (!isContiguous(allMigrations)) {
       throw new DisjointMigrationsException(
         s"Identifiers for migrations MUST be contiguous and start at 0")
     }
-    // Make sure nothing changed with duplicate-removal, and sorting
-    if (allMigrations != trimmedMigrations) {
-      throw new InvalidMigrationSequenceException(
-        s"Provided migrations MUST be ordered by identifier, and contain no duplicates")
-    }
+
     // Disable auto-commit; we absolutely cannot have commits at "random" points
     // during the migration.
     connection.setAutoCommit(false)
@@ -215,7 +308,12 @@ private[peregrin] class MigrationsImpl(connection: Connection, schema: Schema) {
     // and idempotent operation, so we don't need a lock here; indeed
     // we could not possibly take one since we may not actually have
     // a table to lock.
-    createChangeLogIfMissing()
+    changeLogTableDAO.createChangeLogIfMissing()
+    // Create the change log meta data table (if missing). The table
+    // creation is an atomic and idempotent operation, but filling
+    // with default values is not, so an exclusive lock is obtained
+    // on the metadata table after creation.
+    changeLogMetaDataDAO.createChangeLogMetaDataIfMissing()
     // Commit
     connection.commit()
     // Everything else needs the lock; note that this means that
@@ -223,7 +321,7 @@ private[peregrin] class MigrationsImpl(connection: Connection, schema: Schema) {
     // the others wait and will discover that updates have already
     // been performed.
     val appliedChangeLogEntries: Vector[ChangeLogEntry] =
-      withChangeLogLock {
+      changeLogTableDAO.withChangeLogLock {
         // We verify all the change log entries and select which
         // have yet to be applied.
         val changeLogEntriesToApply = verifyChangeLogEntries(allMigrations)
@@ -233,13 +331,7 @@ private[peregrin] class MigrationsImpl(connection: Connection, schema: Schema) {
     // Commit all changes
     connection.commit()
     // Return migration result
-    AppliedMigrations(
-      migrations = appliedChangeLogEntries
-        .map { cl =>
-          Migration(
-            identifier = cl.identifier,
-            sql = cl.sql)
-        })
+    AppliedMigrations(appliedChangeLogEntries.size)
   }
 
 }

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/dao/ChangeLogDAO.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/dao/ChangeLogDAO.scala
@@ -1,0 +1,34 @@
+package dk.cwconsult.peregrin.core.impl.dao
+
+import dk.cwconsult.peregrin.core.impl.ChangeLogEntry
+
+trait ChangeLogDAO {
+
+  /**
+    * Create ChangeLog table, if missing.
+    */
+  def createChangeLogIfMissing(): Unit
+
+  /**
+    * Read a changelog.
+    */
+  def readChangeLogEntries(): Vector[ChangeLogEntry]
+
+  /**
+    * Create a new Change Log Entry in the changelog table
+    */
+  def insertChangeLogEntry(changeLogEntry: ChangeLogEntry): Unit
+
+  /**
+    * Migrate an existing Change Log entry
+    */
+  def updateChangeLogEntry(
+    updatedChangeLogEntry: ChangeLogEntry,
+    oldChangeLogEntry: ChangeLogEntry): Unit
+
+  /**
+    * Run the given block in with a (transactional) lock.
+    */
+  def withChangeLogLock[A](block: => A): A
+
+}

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/dao/ChangeLogDAOImpl.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/dao/ChangeLogDAOImpl.scala
@@ -1,0 +1,213 @@
+package dk.cwconsult.peregrin.core.impl.dao
+
+import java.sql.Connection
+import java.util.UUID
+
+import dk.cwconsult.peregrin.core.Schema
+import dk.cwconsult.peregrin.core.Table
+import dk.cwconsult.peregrin.core.impl.ChangeLogEntry
+import dk.cwconsult.peregrin.core.impl.dao.ChangeLogDAOImpl.ColumnProbe
+import dk.cwconsult.peregrin.core.impl.dao.ChangeLogDAOImpl.ColumnProbe.Exists
+import dk.cwconsult.peregrin.core.impl.dao.ChangeLogDAOImpl.ColumnProbe.Missing
+
+import scala.collection.mutable.ArrayBuffer
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+class ChangeLogDAOImpl(schema: Schema, connection: Connection) extends ChangeLogDAO {
+
+  import dk.cwconsult.peregrin.core.impl.ConnectionImplicits._
+
+  private[this] val changeLogTable =
+    Table(
+      name = "__peregrin_changelog__",
+      schema)
+
+  private[this] val createPeregrinSchema: String =
+    s"CREATE SCHEMA IF NOT EXISTS $schema"
+
+  private[this] val createPeregrinChangeLogTable: String =
+    s"""
+        CREATE TABLE IF NOT EXISTS $changeLogTable (
+          "identifier" INT NOT NULL,
+          "sql" TEXT NOT NULL,
+          "executed" TIMESTAMP WITH TIME ZONE NOT NULL)
+      """.stripMargin
+
+  private[this] val alterPeregrinChangeLogTableAddUUIDId: String =
+    s"""
+        ALTER TABLE $changeLogTable
+        ADD COLUMN "migration_id" UUID
+     """.stripMargin
+
+  private[this] val alterPeregrinChangeLogTableAddParentId: String =
+    s"""
+        ALTER TABLE $changeLogTable
+        ADD COLUMN "migration_parent_id" UUID
+     """.stripMargin
+
+  /**
+    * Create change log if necessary.
+    */
+  override def createChangeLogIfMissing(): Unit = {
+    // Create the schema if necessary.
+    connection.execute(createPeregrinSchema)
+    // Create the migration log table.
+    val _ = connection.execute(createPeregrinChangeLogTable)
+    // Migrate the schema, based on which columns we have available
+    probeAndMigrateTable(changeLogTable)(
+      // Add new UUID identifier for migration, if it doesn't exist already
+      Missing("migration_id") -> {
+        connection.execute(alterPeregrinChangeLogTableAddUUIDId)
+      },
+      // Add new parent UUID identifier, if it doesn't exist already
+      Missing("migration_parent_id") -> {
+        connection.execute(alterPeregrinChangeLogTableAddParentId)
+      })
+  }
+
+  // ---------------------------------------------
+
+  private[this] val selectChangeLogEntries: String =
+    s"""
+        SELECT "identifier", "migration_id", "migration_parent_id", "sql"
+        FROM $changeLogTable
+        ORDER BY "identifier" ASC
+    """.stripMargin
+
+  override def readChangeLogEntries(): Vector[ChangeLogEntry] = {
+    connection.executeQuery(selectChangeLogEntries) { resultSet =>
+      // Extract all the results
+      val rows = new ArrayBuffer[ChangeLogEntry]()
+      while (resultSet.next()) {
+        // Build new changelog entry
+        rows += ChangeLogEntry(
+          legacyIdentifier = resultSet.getInt(1),
+          migrationId = Option(resultSet.getString(2)).map(UUID.fromString),
+          migrationParentId = Option(resultSet.getString(3)).map(UUID.fromString),
+          sql = resultSet.getString(4))
+      }
+      rows.toVector
+    }
+  }
+
+  // ---------------------------------------------
+
+  private[this] val insertChangeLogEntry: String =
+    s"""INSERT INTO $changeLogTable (
+       "identifier", "sql", "migration_id", "migration_parent_id", "executed")
+       VALUES (?, ?, ?, ?, now())""".stripMargin
+
+  def insertChangeLogEntry(changeLogEntry: ChangeLogEntry): Unit = {
+    // Insert the entry.
+    val insertCount = connection.executeUpdatePrepared(insertChangeLogEntry) { stmt =>
+      stmt.setInt(1, changeLogEntry.legacyIdentifier)
+      stmt.setString(2, changeLogEntry.sql)
+      stmt.setObject(3, changeLogEntry.migrationId.orNull)
+      stmt.setObject(4, changeLogEntry.migrationParentId.orNull)
+    }
+    // Sanity check: Must have inserted exactly one row.
+    if (insertCount != 1) {
+      throw new IllegalStateException(s"Internal consistency error: No rows inserted")
+    }
+  }
+
+  // ---------------------------------------------
+
+  private[this] val updateChangeLogEntry: String =
+    s"""UPDATE $changeLogTable SET
+       "identifier" = ?,
+       "migration_id" = ?,
+       "migration_parent_id" = ?,
+       "sql" = ?
+       WHERE
+       "identifier" = ? AND
+       "migration_id" IS NOT DISTINCT FROM ? AND
+       "migration_parent_id" IS NOT DISTINCT FROM ?
+       """.stripMargin
+
+  override def updateChangeLogEntry(updatedChangeLogEntry: ChangeLogEntry, oldChangeLogEntry: ChangeLogEntry): Unit = {
+    // update the entry.
+    val updateCount = connection.executeUpdatePrepared(updateChangeLogEntry) { stmt =>
+      stmt.setObject(1, updatedChangeLogEntry.legacyIdentifier)
+      stmt.setObject(2, updatedChangeLogEntry.migrationId.orNull)
+      stmt.setObject(3, updatedChangeLogEntry.migrationParentId.orNull)
+      stmt.setString(4, updatedChangeLogEntry.sql)
+      // Params
+      stmt.setInt(5, oldChangeLogEntry.legacyIdentifier)
+      stmt.setObject(6, oldChangeLogEntry.migrationId.orNull)
+      stmt.setObject(7, oldChangeLogEntry.migrationParentId.orNull)
+    }
+    // Sanity check: Must have updated exactly one row.
+    if (updateCount != 1) {
+      throw new IllegalStateException(s"Internal consistency error: $updateCount rows updated")
+    }
+  }
+
+  // ---------------------------------------------
+
+  private[this] val lockChangeLogTable: String =
+    s"LOCK $changeLogTable IN EXCLUSIVE MODE"
+
+  override def withChangeLogLock[A](block: => A): A = {
+    connection.execute(lockChangeLogTable)
+    try {
+      block
+    } finally {
+      // Nothing to do; the lock will automatically be released at the end
+      // of the transaction.
+    }
+  }
+
+  // ---------------------------------------------
+
+  /**
+    * Probe a given table for available columns, and process a handler,
+    * if the column either exists or is missing, according to the configuration.
+    */
+  private[this] def probeAndMigrateTable(t: Table)(columnProbes: (ColumnProbe, () => Unit)*): Unit = {
+    // Resolve which probe handlers we need to process
+    val pendingProbeActions: Seq[(ColumnProbe, () => Unit)] =
+      connection.executeQuery(s"SELECT * FROM $t LIMIT 1") { resultSet =>
+        // Process the provided probes, and collect actions to be performed afterwarsd
+        columnProbes.flatMap { probe =>
+          val probeResult = Try(resultSet.findColumn(probe._1.columnName))
+          (probe._1, probeResult) match {
+            case (Exists(_), Success(_)) => Some(probe)
+            case (Exists(_), Failure(_)) => None
+            case (Missing(_), Success(_)) => None
+            case (Missing(_), Failure(_)) => Some(probe)
+          }
+        }
+      }
+    // Run matching handlers
+    pendingProbeActions.foreach { probe =>
+      probe._2()
+    }
+  }
+
+}
+
+object ChangeLogDAOImpl {
+
+  sealed trait ColumnProbe {
+    def columnName: String
+
+    def ->(f: => Unit): (ColumnProbe, () => Unit) =
+      (this, { () => f })
+  }
+
+  object ColumnProbe {
+
+    case class Exists private[dao] (
+      override val columnName: String)
+      extends ColumnProbe
+
+    case class Missing private[dao] (
+      override val columnName: String)
+      extends ColumnProbe
+
+  }
+
+}

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/dao/ChangeLogMetaDataDAO.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/dao/ChangeLogMetaDataDAO.scala
@@ -1,0 +1,22 @@
+package dk.cwconsult.peregrin.core.impl.dao
+
+import dk.cwconsult.peregrin.core.impl.ChangeLogEntry.ChangeLogVersion
+
+trait ChangeLogMetaDataDAO {
+
+  /**
+    * Create ChangeLogMetaData table if missing
+    */
+  def createChangeLogMetaDataIfMissing(): Unit
+
+  /**
+    * Record a new Change Log format version in the metadata table
+    */
+  def writeChangeLogVersion(changeLogVersion: ChangeLogVersion): Unit
+
+  /**
+    * Query metadata table for format version
+    */
+  def readChangeLogVersionOrDefault(): ChangeLogVersion
+
+}

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/dao/ChangeLogMetaDataDAOImpl.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/dao/ChangeLogMetaDataDAOImpl.scala
@@ -1,0 +1,124 @@
+package dk.cwconsult.peregrin.core.impl.dao
+
+import java.sql.Connection
+
+import dk.cwconsult.peregrin.core.InvalidChangeLogVersionException
+import dk.cwconsult.peregrin.core.Schema
+import dk.cwconsult.peregrin.core.Table
+import dk.cwconsult.peregrin.core.impl.ChangeLogEntry.ChangeLogVersion
+import dk.cwconsult.peregrin.core.impl.dao.ChangeLogMetaDataDAOImpl.MetaData
+
+import scala.util.Try
+
+class ChangeLogMetaDataDAOImpl(schema: Schema, connection: Connection) extends ChangeLogMetaDataDAO {
+
+  import dk.cwconsult.peregrin.core.impl.ConnectionImplicits._
+
+  private[this] val metaDataTable =
+    Table(
+      name = "__peregrin_metadata__",
+      schema)
+
+  private[this] val VERSION_IDENTIFIER: String = "version"
+  private[this] val VERSION_DEFAULT_VAL: ChangeLogVersion = ChangeLogVersion.V1
+
+  private[this] val createPeregrinMetaDataTable: String =
+    s"""
+        CREATE TABLE IF NOT EXISTS $metaDataTable (
+          "identifier" VARCHAR(255) NOT NULL,
+          "value" TEXT NOT NULL,
+          PRIMARY KEY ("identifier"))
+      """.stripMargin
+
+
+  private[this] val lockPeregrinMetaDataTable: String =
+    s"LOCK $metaDataTable IN EXCLUSIVE MODE"
+
+  /**
+    * Create meta data table if necessary.
+    */
+  override def createChangeLogMetaDataIfMissing(): Unit = {
+    // Create the migration log table.
+    connection.execute(createPeregrinMetaDataTable)
+    // Lock the table while we inspect the entries (actually until end of transaction)
+    connection.execute(lockPeregrinMetaDataTable)
+    // Determine if we need to create a version entry
+    if (readChangeLogVersion().isEmpty) {
+      // Default to version 1
+      writeChangeLogVersion(VERSION_DEFAULT_VAL)
+    }
+  }
+
+  // ----------------------------------------
+
+  private[this] def readChangeLogVersion(): Option[ChangeLogVersion] =
+    readMetaDataByName(VERSION_IDENTIFIER)
+      .flatMap(_.asInt)
+      .map {
+        case ChangeLogVersion.V1.versionInt => ChangeLogVersion.V1
+        case ChangeLogVersion.V2.versionInt => ChangeLogVersion.V2
+        case ChangeLogVersion.V3.versionInt => ChangeLogVersion.V3
+        case other => throw new InvalidChangeLogVersionException(
+          s"Invalid version in changelog entry: $other")
+      }
+
+  override def readChangeLogVersionOrDefault(): ChangeLogVersion =
+    readChangeLogVersion().getOrElse(VERSION_DEFAULT_VAL)
+
+  override def writeChangeLogVersion(changeLogVersion: ChangeLogVersion): Unit =
+    writeMetaDataValue(VERSION_IDENTIFIER, changeLogVersion.versionInt.toString)
+
+  // ----------------------------------------
+
+  private[this] val selectMetaDataIdentifierValue: String =
+    s"""
+       SELECT "identifier", "value" FROM $metaDataTable
+       WHERE "identifier" = ?
+     """.stripMargin
+
+  private[this] def readMetaDataByName(identifier: String): Option[MetaData] =
+    connection.executeQueryPrepared(selectMetaDataIdentifierValue) { stmt =>
+      stmt.setString(1, identifier)
+    } { resultSet =>
+      Iterator
+        .continually(resultSet.next())
+        .takeWhile(identity)
+        .flatMap(_ => Option(resultSet.getString(2)))
+        .map(MetaData)
+        .toVector
+        .headOption
+    }
+
+  // ----------------------------------------
+
+  private[this] val insertMetaDataEntry: String =
+    s"""INSERT INTO $metaDataTable ("value", "identifier") VALUES (?, ?)"""
+
+  private[this] val updateMetaDataEntry: String =
+    s"""UPDATE $metaDataTable SET "value" = ? WHERE "identifier" = ?"""
+
+  private[this] def writeMetaDataValue(identifier: String, value: String): Unit = {
+    // Determine if we need to do an update or insert
+    val upsertQuery = readMetaDataByName(identifier) match {
+      case Some(_) => updateMetaDataEntry
+      case None => insertMetaDataEntry
+    }
+    // Perform the UPSERT
+    connection.executeUpdatePrepared(upsertQuery) { stmt =>
+      // The ordering of parameters is identical for both INSERT and UPDATE query
+      stmt.setString(1, value)
+      stmt.setString(2, identifier)
+    }
+  }
+
+}
+
+object ChangeLogMetaDataDAOImpl {
+
+  case class MetaData private[ChangeLogMetaDataDAOImpl] (value: String) {
+    def asInt: Option[Int] = Try(value.toInt).toOption
+  }
+
+}
+
+

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/migrations/MigrationId.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/migrations/MigrationId.scala
@@ -1,0 +1,18 @@
+package dk.cwconsult.peregrin.core.migrations
+
+import java.util.UUID
+
+sealed trait MigrationId
+
+object MigrationId {
+
+  case class LegacyId(
+    legacyId: Int)
+    extends MigrationId
+
+  case class ChildParentRelation(
+    id: UUID,
+    parentId: Option[UUID])
+    extends MigrationId
+
+}

--- a/modules/core/src/test/scala/dk/cwconsult/peregrin/core/impl/MigrateChangeLogSpec.scala
+++ b/modules/core/src/test/scala/dk/cwconsult/peregrin/core/impl/MigrateChangeLogSpec.scala
@@ -1,0 +1,239 @@
+package dk.cwconsult.peregrin.core.impl
+
+import java.util.UUID
+
+import dk.cwconsult.peregrin.core.InvalidMigrationSequenceException
+import dk.cwconsult.peregrin.core.Migration
+import dk.cwconsult.peregrin.core.Schema
+import dk.cwconsult.peregrin.core.UnresolvedChangeLogEntriesFoundException
+import dk.cwconsult.peregrin.core.test.Fixture
+import org.scalatest.WordSpec
+
+class MigrateChangeLogSpec extends WordSpec {
+
+  private[this] val migrationId0 = UUID.randomUUID()
+
+
+  for (schema <- Vector(Schema.Public, Schema.Named(UUID.randomUUID.toString))) {
+
+    "Migration.applyMigrations method" when {
+      s"applied to schema $schema" should {
+
+        "allow migration of an empty sequence" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Exercise
+            migrate(Seq.empty)
+            // Verify: no change logs
+            assert(readMigrations().isEmpty)
+          }
+        }
+
+        "throws an exception if a migration is missing a legacy id, if provided for one" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Exercise
+            val exception = intercept[InvalidMigrationSequenceException] {
+              migrate(Seq(
+                Migration(0, createXSql),
+                Migration(migrationId0, None, createYSql)))
+            }
+            // Verify
+            assert(exception.getMessage.contains("MUST have a common identifier type defined"))
+          }
+        }
+
+        "throws an exception if a migration is missing a child-parent relation, if provided for one" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Exercise
+            val exception = intercept[InvalidMigrationSequenceException] {
+              migrate(Seq(
+                Migration(0, createXSql),
+                Migration(1, migrationId0, None, createYSql)))
+            }
+            // Verify
+            assert(exception.getMessage.contains("ALL MUST be given a UUID identifier"))
+          }
+        }
+
+        "migrate changelog V1 entries to V2" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Setup: Prepare changelog db with a V1 entry
+            migrate(Seq(
+              Migration(0, createXSql)))
+
+            // Setup: Verify DB contains V1 entry
+            val v1Migrations = readMigrations()
+            assert(v1Migrations.nonEmpty)
+            assert(v1Migrations.head.legacyId === 0)
+            assert(v1Migrations.head.migrationId === None)
+            assert(v1Migrations.head.migrationParentId === None)
+            assertChangeLogVersionIs(1)
+
+            // Setup: Verify existence of X
+            assertCanSelectFromX()
+
+            // Exercise: Migrate change log entry to V2 format
+            migrate(Seq(
+              Migration(0, migrationId0, None, createXSql)))
+
+            // Verify
+            val migrations = readMigrations()
+            assert(migrations.length === 1)
+            assert(migrations.head.legacyId === 0)
+            assert(migrations.head.migrationId === Some(migrationId0))
+            assert(migrations.head.migrationParentId === None)
+            assertChangeLogVersionIs(2)
+
+          }
+        }
+
+        "migrate changelog V2 entries to V3" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Setup: Prepare changelog db with a V3 entry
+            migrate(Seq(
+              Migration(0, migrationId0, None, createXSql)))
+
+            // Setup: Verify DB contains V2 entry
+            val v1Migrations = readMigrations()
+            assert(v1Migrations.length === 1)
+            assert(v1Migrations.head.legacyId === 0)
+            assert(v1Migrations.head.migrationId === Some(migrationId0))
+            assert(v1Migrations.head.migrationParentId === None)
+            assertChangeLogVersionIs(2)
+
+            // Setup: Verify existence of X
+            assertCanSelectFromX()
+
+            // Exercise: Migrate change log entry to V3 format
+            migrate(Seq(
+              Migration(migrationId0, None, createXSql)))
+
+            // Setup: Verify DB contains V2 entry
+            val migrations = readMigrations()
+            assert(migrations.length === 1)
+            assert(migrations.head.legacyId === 0)
+            assert(migrations.head.migrationId === Some(migrationId0))
+            assert(migrations.head.migrationParentId === None)
+            assertChangeLogVersionIs(3)
+
+          }
+        }
+
+        "migrate changelog V1 entries to V2 and V3" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Setup: Prepare changelog db with a V1 entry
+            migrate(Seq(
+              Migration(0, createXSql)))
+
+            // Setup: Verify DB contains V1 entry
+            val v1Migrations = readMigrations()
+            assert(v1Migrations.nonEmpty)
+            assert(v1Migrations.head.legacyId === 0)
+            assert(v1Migrations.head.migrationId === None)
+            assert(v1Migrations.head.migrationParentId === None)
+            assertChangeLogVersionIs(1)
+
+            // Setup: Verify existence of X
+            assertCanSelectFromX()
+
+            // Exercise: Migrate change log entry to V2 format
+            migrate(Seq(
+              Migration(0, migrationId0, None, createXSql)))
+
+            // Verify migration to V2
+            val v2Migrations = readMigrations()
+            assert(v2Migrations.length === 1)
+            assert(v2Migrations.head.legacyId === 0)
+            assert(v2Migrations.head.migrationId === Some(migrationId0))
+            assert(v2Migrations.head.migrationParentId === None)
+            assertChangeLogVersionIs(2)
+
+            // Exercise: Migrate change log entry to V3 format
+            migrate(Seq(
+              Migration(migrationId0, None, createXSql)))
+
+            // Setup: Verify DB contains V3 entry
+            val migrations = readMigrations()
+            assert(migrations.length === 1)
+            assert(migrations.head.legacyId === 0)
+            assert(migrations.head.migrationId === Some(migrationId0))
+            assert(migrations.head.migrationParentId === None)
+            assertChangeLogVersionIs(3)
+          }
+        }
+
+        "abort migration from changelog V1 entries directly to V3" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Setup: Prepare changelog db with a V1 entry
+            migrate(Seq(
+              Migration(0, createXSql)))
+
+            // Setup: Verify DB contains V1 entry
+            val v1Migrations = readMigrations()
+            assert(v1Migrations.nonEmpty)
+            assert(v1Migrations.head.legacyId === 0)
+            assert(v1Migrations.head.migrationId === None)
+            assert(v1Migrations.head.migrationParentId === None)
+            assertChangeLogVersionIs(1)
+
+            // Setup: Verify existence of X
+            assertCanSelectFromX()
+
+            // Exercise: Attempt to migrate directly to V3 format
+            val exception = intercept[UnresolvedChangeLogEntriesFoundException] {
+              migrate(Seq(
+                Migration(migrationId0, None, createXSql)))
+            }
+            assert(exception.getMessage.contains("MUST include all known change log entries"))
+          }
+        }
+
+        "migrate changelog V3 entries to V2 and V1" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Setup: Prepare changelog db with a V3 entry
+            migrate(Seq(
+              Migration(migrationId0, None, createXSql)))
+
+            // Setup: Verify DB contains V3 entry
+            val v3Migrations = readMigrations()
+            assert(v3Migrations.nonEmpty)
+            assert(v3Migrations.head.legacyId === -1)
+            assert(v3Migrations.head.migrationId === Some(migrationId0))
+            assert(v3Migrations.head.migrationParentId === None)
+            assertChangeLogVersionIs(3)
+
+            // Setup: Verify existence of X
+            assertCanSelectFromX()
+
+            // Exercise: Migrate change log entry to V2 format
+            migrate(Seq(
+              Migration(0, migrationId0, None, createXSql)))
+
+            // Verify migration to V2
+            val v2Migrations = readMigrations()
+            assert(v2Migrations.length === 1)
+            assert(v2Migrations.head.legacyId === 0)
+            assert(v2Migrations.head.migrationId === Some(migrationId0))
+            assert(v2Migrations.head.migrationParentId === None)
+            assertChangeLogVersionIs(3)
+
+            // Exercise: Migrate change log entry to V1 format
+            migrate(Seq(
+              Migration(0, createXSql)))
+
+            // Verify: Verify DB contains V3 entry with V1 info
+            val migrations = readMigrations()
+            assert(migrations.length === 1)
+            assert(migrations.head.legacyId === 0)
+            assert(migrations.head.migrationId === Some(migrationId0))
+            assert(migrations.head.migrationParentId === None)
+            assertChangeLogVersionIs(3)
+          }
+        }
+
+
+      }
+    }
+
+  }
+
+}

--- a/modules/core/src/test/scala/dk/cwconsult/peregrin/core/impl/MigrationsImplSpec.scala
+++ b/modules/core/src/test/scala/dk/cwconsult/peregrin/core/impl/MigrationsImplSpec.scala
@@ -6,75 +6,11 @@ import dk.cwconsult.peregrin.core.DisjointMigrationsException
 import dk.cwconsult.peregrin.core.InvalidMigrationSequenceException
 import dk.cwconsult.peregrin.core.Migration
 import dk.cwconsult.peregrin.core.MigrationModifiedException
-import dk.cwconsult.peregrin.core.Migrations
 import dk.cwconsult.peregrin.core.Schema
-import dk.cwconsult.peregrin.core.Table
-import dk.cwconsult.peregrin.core.test.TempgresConnection
-import org.scalatest.Assertion
+import dk.cwconsult.peregrin.core.test.Fixture
 import org.scalatest.WordSpec
-import scalikejdbc.ConnectionPool
-import scalikejdbc.DB
-import scalikejdbc.DBSession
-import scalikejdbc.LoanPattern
 
 class MigrationsImplSpec extends WordSpec {
-
-  /**
-  * Fixture for running the tests.
-  */
-  class Fixture(schema: Schema) {
-
-    val connectionPool: ConnectionPool =
-      TempgresConnection.createConnectionPool()
-
-    val createXSql: String = "CREATE TABLE X (A INT)"
-    val createYSql: String = "CREATE TABLE Y (B INT)"
-    val createXSqlBad: String = "CREATE TABLE X (Y CHAR(1))"
-    val createTableSql: String = "CREATE TABLE ? (X INT)"
-
-    def assertCanQuery(sql: String)(implicit dbSession: DBSession): Assertion = {
-      // Force a query; we are relying on the "list" function being strict here.
-      dbSession.list[Unit](sql)(rs => ())
-      // If we didn't have an exception, then we are certain that the relevant
-      // change sets were applied.
-      succeed
-    }
-
-    def readMigrations()(implicit dbSession: DBSession): Seq[(Int, String)] =
-      dbSession.list[(Int, String)](
-        s"""
-           |  SELECT "identifier", "sql"
-           |    FROM $schema."__peregrin_changelog__"
-           |ORDER BY "identifier" ASC
-           |""".stripMargin)(rs => (rs.int(1), rs.string(2)))
-
-    def assertCanSelectFromX()(implicit dbSession: DBSession): Assertion =
-      assertCanQuery("SELECT * FROM X")
-
-    def assertCanSelectFromP(p: Table)(implicit dbSession: DBSession): Assertion =
-      assertCanQuery(s"SELECT * FROM $p")
-
-    def assertCanSelectFromPP(p: Table)(implicit dbSession: DBSession): Assertion =
-      assertCanQuery(s"SELECT * FROM $p, $p")
-
-    def assertCanSelectFromXY()(implicit dbSession: DBSession): Assertion =
-      assertCanQuery("SELECT * FROM X, Y")
-
-    def migrate(migrations: Seq[Migration])(implicit dbSession: DBSession): Unit = {
-      val _ = Migrations.applyMigrations(dbSession.connection, schema, migrations)
-    }
-
-    def withTransaction(f: DBSession => Assertion): Assertion = {
-      LoanPattern.using(connectionPool.borrow()) { connection =>
-        DB(connection).localTx { implicit session =>
-          f(session)
-        }
-      }
-    }
-
-  }
-
-  // -----------------------------------------------------------
 
   for (schema <- Vector(Schema.Public, Schema.Named(UUID.randomUUID.toString))) {
 

--- a/modules/core/src/test/scala/dk/cwconsult/peregrin/core/impl/MigrationsImplSpec.scala
+++ b/modules/core/src/test/scala/dk/cwconsult/peregrin/core/impl/MigrationsImplSpec.scala
@@ -9,16 +9,13 @@ import dk.cwconsult.peregrin.core.MigrationModifiedException
 import dk.cwconsult.peregrin.core.Migrations
 import dk.cwconsult.peregrin.core.Schema
 import dk.cwconsult.peregrin.core.Table
-import dk.cwconsult.peregrin.core.impl.MigrationsImplSpec.createConnectionPool
-import dk.cwconsult.tempgres.TempgresClient
+import dk.cwconsult.peregrin.core.test.TempgresConnection
 import org.scalatest.Assertion
 import org.scalatest.WordSpec
 import scalikejdbc.ConnectionPool
 import scalikejdbc.DB
 import scalikejdbc.DBSession
-import scalikejdbc.GlobalSettings
 import scalikejdbc.LoanPattern
-import scalikejdbc.LoggingSQLAndTimeSettings
 
 class MigrationsImplSpec extends WordSpec {
 
@@ -28,7 +25,7 @@ class MigrationsImplSpec extends WordSpec {
   class Fixture(schema: Schema) {
 
     val connectionPool: ConnectionPool =
-      createConnectionPool()
+      TempgresConnection.createConnectionPool()
 
     val createXSql: String = "CREATE TABLE X (A INT)"
     val createYSql: String = "CREATE TABLE Y (B INT)"
@@ -213,40 +210,6 @@ class MigrationsImplSpec extends WordSpec {
       }
     }
 
-  }
-
-}
-
-object MigrationsImplSpec {
-
-  /**
-   * Create connection pool connected to a temporary database.
-   */
-  def createConnectionPool(): ConnectionPool = {
-    // Generate connection pool name which is unlikely to collide with anything.
-    // We use this as a way to catch mistakes where the wrong connection pool
-    // is being accessed. This also prevents conflicts with other tests which
-    // could run simultaneously.
-    val connectionPoolName: String =
-      UUID.randomUUID().toString
-
-    // Create the database and connection pool
-    val database =
-      TempgresClient.createTemporaryDatabase(System.getProperty("tempgres.url", "http://tempgres:8080"))
-
-    ConnectionPool.add(
-      connectionPoolName,
-      database.getUrl,
-      database.getCredentials.getUserName,
-      database.getCredentials.getPassword)
-
-    // Reduce log spam.
-    GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(
-      singleLineMode = true,
-      logLevel = 'trace)
-
-    // Return the connection pool
-    ConnectionPool.get(connectionPoolName)
   }
 
 }

--- a/modules/core/src/test/scala/dk/cwconsult/peregrin/core/impl/MigrationsV3ImplSpec.scala
+++ b/modules/core/src/test/scala/dk/cwconsult/peregrin/core/impl/MigrationsV3ImplSpec.scala
@@ -1,0 +1,203 @@
+package dk.cwconsult.peregrin.core.impl
+
+import java.util.UUID
+
+import dk.cwconsult.peregrin.core.DisjointMigrationsException
+import dk.cwconsult.peregrin.core.InvalidMigrationSequenceException
+import dk.cwconsult.peregrin.core.Migration
+import dk.cwconsult.peregrin.core.MigrationModifiedException
+import dk.cwconsult.peregrin.core.Schema
+import dk.cwconsult.peregrin.core.test.Fixture
+import org.scalatest.WordSpec
+
+class MigrationsV3ImplSpec extends WordSpec {
+
+  for (schema <- Vector(Schema.Public, Schema.Named(UUID.randomUUID.toString))) {
+
+    val migrationId0 = UUID.randomUUID()
+    val migrationId1 = UUID.randomUUID()
+    val migrationId2 = UUID.randomUUID()
+
+    "MigrationiV3.applyMigrations method" when {
+      s"applied to schema $schema" should {
+
+        "require at least one root node" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Exercise
+            val exception = intercept[InvalidMigrationSequenceException] {
+              migrate(Seq(
+                Migration(migrationId1, Some(migrationId0), createXSql)))
+            }
+            // Verify
+            assert(exception.getMessage.contains("MUST contain at least one root node"))
+          }
+        }
+
+        "can apply a single migration" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Exercise
+            migrate(Seq(
+              Migration(migrationId0, None, createXSql)))
+            // Verify
+            assertCanSelectFromX()
+          }
+        }
+
+        "abort if duplicate migrations are provided(single call)" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            assertThrows[InvalidMigrationSequenceException] {
+              // Exercise
+              migrate(Seq(
+                Migration(migrationId0, None, createXSql),
+                Migration(migrationId0, None, createXSql))) // Causes aborted migration
+            }
+          }
+        }
+
+        "ignores migrations that have already been applied (multiple calls)" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Exercise
+            migrate(Seq(
+              Migration(migrationId0, None, createXSql)))
+            migrate(Seq(
+              Migration(migrationId0, None, createXSql))) // Would fail if applied again
+            // Verify
+            assertCanSelectFromX()
+          }
+        }
+
+        "throws an exception if SQL is changes for a given change set ID (single call)" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Exercise
+            val exception = intercept[MigrationModifiedException] {
+              migrate(Seq(
+                Migration(migrationId0, None, createXSql),
+                Migration(migrationId0, None, createXSqlBad)))
+            }
+            // Verify
+            assert(exception.getMessage.contains("does not match"))
+          }
+        }
+
+        "throws an exception if SQL is changed for a given change set ID (multiple calls)" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Exercise
+            migrate(Seq(
+              Migration(migrationId0, None, createXSql)))
+            val exception = intercept[MigrationModifiedException] {
+              migrate(Seq(
+                Migration(migrationId0, None, createXSqlBad)))
+            }
+            // Verify
+            assert(exception.getMessage.contains("does not match"))
+          }
+        }
+
+        "can apply multiple distinct migrations in a single call" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Exercise
+            migrate(Seq(
+              Migration(migrationId0, None, createXSql),
+              Migration(migrationId1, Some(migrationId0), createYSql)))
+            // Verify: Make sure both migrations have been applied
+            assertCanSelectFromXY()
+          }
+        }
+
+        "throws an exception for sequences with references to unknown migrations" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Exercise
+            val exception = intercept[InvalidMigrationSequenceException] {
+              migrate(Seq(
+                Migration(migrationId0, None, createXSql),
+                Migration(migrationId1, Some(migrationId2), createYSql)))
+            }
+            // Verify
+            assert(exception.getMessage.contains("MUST reference valid parents"))
+          }
+        }
+
+        "trim whitespace from beginning/end of SQL on insert" in new Fixture(schema) {
+          withTransaction { implicit sessions =>
+            // Exercise: Create the migration
+            migrate(Seq(
+              Migration(migrationId0, None, "\t    " + createXSql + "    ")
+            ))
+            // Verify
+            val migrations = readMigrations()
+            assert(migrations.head.legacyId === -1)
+            assert(migrations.head.migrationId === Some(migrationId0))
+            assert(migrations.head.migrationParentId === None)
+            assert(!migrations.head.sql.head.isSpaceChar)
+            assert(!migrations.head.sql.last.isSpaceChar)
+            assertCanSelectFromX()
+          }
+        }
+
+        "ignore differences in whitespace from beginning/end of SQL" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Exercise: Create the 'base' migration
+            migrate(Seq(
+              Migration(migrationId0, None, createXSql)
+            ))
+            // Exercise: Add 'spurious' whitespace
+            migrate(Seq(
+              Migration(migrationId0, None, "  \t\n" + createXSql + "\r\n")
+            ))
+            // If we get here, we're OK
+            succeed
+          }
+        }
+
+        "have deterministic order of execution" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            val migrationId2 = UUID.randomUUID()
+            val migrationId3 = UUID.randomUUID()
+            val migrationId4 = UUID.randomUUID()
+            val migrationId5 = UUID.randomUUID()
+            // Exercise
+            migrate(Seq(
+              Migration(migrationId0, None, createXSql),
+              Migration(migrationId1, Some(migrationId0),
+                "ALTER TABLE X RENAME COLUMN A TO B"),
+              Migration(migrationId2, Some(migrationId0),
+                "ALTER TABLE X RENAME COLUMN B TO C"),
+              Migration(migrationId3, Some(migrationId0),
+                "ALTER TABLE X RENAME COLUMN C TO D"),
+
+              // This should be performed last, because it's
+              // deepest in the tree
+              Migration(migrationId4, Some(migrationId2),
+                "ALTER TABLE X RENAME COLUMN E TO F"),
+
+              Migration(migrationId5, Some(migrationId0),
+                "ALTER TABLE X RENAME COLUMN D TO E")))
+            // Verify: Make sure both migrations have been applied
+            assertCanQuery("SELECT F FROM X")
+          }
+        }
+
+        "report any cycles in migration order as unresolved migrations" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            val migrationId2 = UUID.randomUUID()
+            val migrationId3 = UUID.randomUUID()
+            val migrationId4 = UUID.randomUUID()
+            // Exercise
+            val exception = intercept[InvalidMigrationSequenceException] {
+              migrate(Seq(
+                Migration(migrationId0, None, createXSql),
+                Migration(migrationId2, Some(migrationId3), createTableSql("A")),
+                Migration(migrationId3, Some(migrationId2), createTableSql("B")),
+                Migration(migrationId4, Some(migrationId0), createYSql)
+              ))
+            }
+            assert(exception.getMessage.contains("Do you have a cycle?"))
+          }
+        }
+
+      }
+    }
+
+  }
+
+}

--- a/modules/core/src/test/scala/dk/cwconsult/peregrin/core/test/Fixture.scala
+++ b/modules/core/src/test/scala/dk/cwconsult/peregrin/core/test/Fixture.scala
@@ -1,0 +1,68 @@
+package dk.cwconsult.peregrin.core.test
+
+import dk.cwconsult.peregrin.core.Migration
+import dk.cwconsult.peregrin.core.Migrations
+import dk.cwconsult.peregrin.core.Schema
+import dk.cwconsult.peregrin.core.Table
+import org.scalatest.Assertion
+import org.scalatest.Assertions
+import scalikejdbc.ConnectionPool
+import scalikejdbc.DB
+import scalikejdbc.DBSession
+import scalikejdbc.LoanPattern
+
+/**
+ * Fixture for running the tests.
+ */
+class Fixture(schema: Schema) {
+
+  val connectionPool: ConnectionPool =
+    TempgresConnection.createConnectionPool()
+
+  val createXSql: String = "CREATE TABLE X (A INT)"
+  val createYSql: String = "CREATE TABLE Y (B INT)"
+  val createXSqlBad: String = "CREATE TABLE X (Y CHAR(1))"
+  val createTableSql: String = "CREATE TABLE ? (X INT)"
+
+  def assertCanQuery(sql  : String)(implicit dbSession: DBSession): Assertion = {
+    // Force a query; we are relying on the "list" function being strict here.
+    dbSession.list[Unit](sql)(rs => ())
+    // If we didn't have an exception, then we are certain that the relevant
+    // change sets were applied.
+    Assertions.succeed
+  }
+
+  def readMigrations()(implicit dbSession: DBSession): Seq[(Int, String)] =
+    dbSession.list[(Int, String)](
+      s"""
+         |  SELECT "identifier", "sql"
+         |    FROM $schema."__peregrin_changelog__"
+         |ORDER BY "identifier" ASC
+         |""".stripMargin)(rs => (rs.int(1), rs.string(2)))
+
+  def assertCanSelectFromX()(implicit dbSession: DBSession): Assertion =
+    assertCanQuery("SELECT * FROM X")
+
+  def assertCanSelectFromP(p: Table)(implicit dbSession: DBSession): Assertion =
+    assertCanQuery(s"SELECT * FROM $p")
+
+  def assertCanSelectFromPP(p: Table)(implicit dbSession: DBSession): Assertion =
+    assertCanQuery(s"SELECT * FROM $p, $p")
+
+  def assertCanSelectFromXY()(implicit dbSession: DBSession): Assertion =
+    assertCanQuery("SELECT * FROM X, Y")
+
+  def migrate(migrations: Seq[Migration])(implicit dbSession: DBSession): Unit = {
+    val _ = Migrations.applyMigrations(dbSession.connection, schema, migrations)
+  }
+
+  def withTransaction(f: DBSession => Assertion): Assertion = {
+    LoanPattern.using(connectionPool.borrow()) { connection =>
+      DB(connection).localTx { implicit session =>
+        f(session)
+      }
+    }
+  }
+
+}
+

--- a/modules/core/src/test/scala/dk/cwconsult/peregrin/core/test/TempgresConnection.scala
+++ b/modules/core/src/test/scala/dk/cwconsult/peregrin/core/test/TempgresConnection.scala
@@ -1,0 +1,42 @@
+package dk.cwconsult.peregrin.core.test
+
+import java.util.UUID
+
+import dk.cwconsult.tempgres.TempgresClient
+import scalikejdbc.ConnectionPool
+import scalikejdbc.GlobalSettings
+import scalikejdbc.LoggingSQLAndTimeSettings
+
+object TempgresConnection {
+
+  /**
+   * Create connection pool connected to a temporary database.
+   */
+  def createConnectionPool(): ConnectionPool = {
+    // Generate connection pool name which is unlikely to collide with anything.
+    // We use this as a way to catch mistakes where the wrong connection pool
+    // is being accessed. This also prevents conflicts with other tests which
+    // could run simultaneously.
+    val connectionPoolName: String =
+      UUID.randomUUID().toString
+
+    // Create the database and connection pool
+    val database =
+      TempgresClient.createTemporaryDatabase(System.getProperty("tempgres.url", "http://tempgres:8080"))
+
+    ConnectionPool.add(
+      connectionPoolName,
+      database.getUrl,
+      database.getCredentials.getUserName,
+      database.getCredentials.getPassword)
+
+    // Reduce log spam.
+    GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(
+      singleLineMode = true,
+      logLevel = 'trace)
+
+    // Return the connection pool
+    ConnectionPool.get(connectionPoolName)
+  }
+
+}


### PR DESCRIPTION
The requirement for contiguous, persistent integer id's
hinders the composability of multi-source migrations. This
commit introduces a parent-child declared chain for migration
ordering, instead of the integer based.

This version is fully complatible with API and database
changelogs for older versions. Existing projects that wish
to move to the parent-child chain, will need to perform a
stepwise migration from format 1 over format 2 to 3, to
associate the new identifiers with existing changelog entries
in running environments.

It is supported to migrate all the way *back* to version 1,
from version 3 (as long as it's over version 2), so rollback
to a previous version should generally be possible, depending
on the compatibility of the schema changes of the new version,
with the application logic of the previous version.