### PR TITLE
Add UUID identifier in new version format

### DIFF
--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/AppliedMigrations.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/AppliedMigrations.scala
@@ -1,8 +1,3 @@
 package dk.cwconsult.peregrin.core
 
-case class AppliedMigrations(migrations: Vector[Migration]) {
-
-  def count: Int =
-    migrations.size
-
-}
+case class AppliedMigrations(count: Int)

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/ImpossibleChangeLogMigrationException.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/ImpossibleChangeLogMigrationException.scala
@@ -1,0 +1,6 @@
+package dk.cwconsult.peregrin.core
+
+class ImpossibleChangeLogMigrationException(
+  message: String,
+  throwable: Throwable = null)
+  extends MigrationException(message, throwable)

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/InvalidChangeLogVersionException.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/InvalidChangeLogVersionException.scala
@@ -1,0 +1,6 @@
+package dk.cwconsult.peregrin.core
+
+class InvalidChangeLogVersionException(
+  message: String,
+  throwable: Throwable = null)
+  extends MigrationException(message, throwable)

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/Migration.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/Migration.scala
@@ -1,8 +1,25 @@
 package dk.cwconsult.peregrin.core
 
+import java.util.UUID
+
+import dk.cwconsult.peregrin.core.{migrations => internal}
+
 /**
- * Migration step.
- */
+  * Migration step.
+  */
 case class Migration(
   identifier: Int,
   sql: String)
+
+object Migration {
+
+  def apply(uuid: String, sql: String): internal.Migration =
+    internal.Migration(uuid = uuid, sql = sql)
+
+  def apply(uuid: UUID, sql: String): internal.Migration =
+    internal.Migration(uuid, sql)
+
+  def apply(legacyIdentifier: Int, uuid: UUID, sql: String): internal.Migration =
+    internal.Migration(legacyIdentifier, uuid, sql)
+
+}

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/Migrations.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/Migrations.scala
@@ -2,15 +2,30 @@ package dk.cwconsult.peregrin.core
 
 import java.sql.Connection
 
+import dk.cwconsult.peregrin.core
 import dk.cwconsult.peregrin.core.impl.MigrationsImpl
+import dk.cwconsult.peregrin.core.migrations.MigrationId.LegacyId
+import dk.cwconsult.peregrin.core.{migrations => internal}
 
 object Migrations {
 
   /**
     * Apply a list of migrations to the given database schema.
+    *
+    * Must all be of the same Migration definition format.
     */
-  def applyMigrations(connection: Connection, schema: Schema, migrations: Seq[Migration]): AppliedMigrations = {
-    new MigrationsImpl(connection, schema).applyChangeLog(migrations.toVector)
+  def applyMigrations(connection: Connection, schema: Schema, migrations: Seq[core.Migration]): AppliedMigrations = {
+    applyMigrations(connection, schema,
+      migrations.map(externalToInternal).toVector)
   }
+
+  def applyMigrations(connection: Connection, schema: Schema, migrations: Vector[internal.Migration]): AppliedMigrations = {
+    new MigrationsImpl(connection, schema).applyChangeLog(migrations)
+  }
+
+  private[this] def externalToInternal(migration: Migration): internal.Migration =
+    internal.Migration.MigrationV1(
+      identifier = LegacyId(migration.identifier),
+      sql = migration.sql)
 
 }

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/Schema.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/Schema.scala
@@ -12,6 +12,11 @@ sealed trait Schema {
   protected[this] def asSql: String
 
   /**
+    * Return a string representation, safe from quotes
+    */
+  def name: String
+
+  /**
     * Return a string representing an SQL-safe string representing the Schema.
     */
   override final def toString(): String =
@@ -29,7 +34,7 @@ object Schema {
     // Private implementation to avoid direct pattern matching
     // since we cannot properly support safe pattern matching on
     // given the "special" names.
-    private[Named] case class NamedImpl(name: String) extends Schema {
+    private[Named] case class NamedImpl(override val name: String) extends Schema {
       override val asSql: String =
         SQLSupport.quoteIdentifier(name)
     }

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/UnresolvedChangeLogEntriesFoundException.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/UnresolvedChangeLogEntriesFoundException.scala
@@ -1,0 +1,6 @@
+package dk.cwconsult.peregrin.core
+
+class UnresolvedChangeLogEntriesFoundException(
+  message: String,
+  throwable: Throwable = null)
+  extends MigrationException(message, throwable)

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/ChangeLogEntry.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/ChangeLogEntry.scala
@@ -1,5 +1,23 @@
 package dk.cwconsult.peregrin.core.impl
 
+import java.util.UUID
+
 private[impl] case class ChangeLogEntry(
-  identifier: Int,
+  legacyIdentifier: Int,
+  migrationId: Option[UUID],
   sql: String)
+
+object ChangeLogEntry {
+
+  sealed abstract class ChangeLogVersion(
+    val versionInt: Int)
+
+  object ChangeLogVersion {
+
+    case object V1 extends ChangeLogVersion(1)
+    case object V2 extends ChangeLogVersion(2)
+    case object V3 extends ChangeLogVersion(3)
+
+  }
+
+}

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/ChangeLogResolver.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/ChangeLogResolver.scala
@@ -1,0 +1,45 @@
+package dk.cwconsult.peregrin.core.impl
+
+import dk.cwconsult.peregrin.core.migrations.Migration
+import dk.cwconsult.peregrin.core.migrations.Migration.MigrationV1
+import dk.cwconsult.peregrin.core.migrations.Migration.MigrationV2
+import dk.cwconsult.peregrin.core.migrations.Migration.MigrationV3
+
+object ChangeLogResolver {
+
+  case class ChangeLogEntries(
+    unresolvedEntries: Seq[ChangeLogEntry],
+    migrationsWithEntries: Seq[(Migration, Option[ChangeLogEntry])])
+
+  def resolveChangeLogEntries(
+    migrations: Seq[Migration],
+    changeLogEntries: Seq[ChangeLogEntry]
+  ): ChangeLogEntries = {
+    // Perform mapping
+    val mappings =
+      for (migration <- migrations) yield {
+        val maybeMatchingChangeLog =
+          changeLogEntries.find(correspondsTo(migration, _))
+        (migration, maybeMatchingChangeLog)
+      }
+    // Resolve changelog entries that were not resolved
+    val unresolved =
+      changeLogEntries.filterNot(e => mappings.exists(_._2.contains(e)))
+    // Return result
+    ChangeLogEntries(
+      unresolvedEntries = unresolved,
+      migrationsWithEntries = mappings)
+  }
+
+  private[this] def correspondsTo(m: Migration, changeLogEntryRow: ChangeLogEntry): Boolean =
+    m match {
+      case v1: MigrationV1 =>
+        v1.identifier.legacyId == changeLogEntryRow.legacyIdentifier
+      case v2: MigrationV2 =>
+        v2.legacyId.legacyId == changeLogEntryRow.legacyIdentifier ||
+          changeLogEntryRow.migrationId.contains(v2.identifier.id)
+      case v3: MigrationV3 =>
+        changeLogEntryRow.migrationId.contains(v3.identifier.id)
+    }
+
+}

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/MigrateChangeLogEntry.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/MigrateChangeLogEntry.scala
@@ -1,0 +1,77 @@
+package dk.cwconsult.peregrin.core.impl
+
+import dk.cwconsult.peregrin.core.migrations.Migration.MigrationV1
+import dk.cwconsult.peregrin.core.migrations.Migration.MigrationV2
+import dk.cwconsult.peregrin.core.migrations.Migration.MigrationV3
+import dk.cwconsult.peregrin.core.impl.ChangeLogEntry.ChangeLogVersion
+import dk.cwconsult.peregrin.core.migrations.Migration
+
+/**
+  * Migrate a given ChangeLogEntry to the used Migration version.
+  *
+  * In down-grade scenarios, new information is augmented to the
+  * entry, but the version identifier will not be decremented.
+  *
+  * This means, that a migration from V3 to V1 is possible, as long
+  * as V2 is used as an intermediate step. But the entry in the
+  * change log, will still declare itself as a V3 compatible entry.
+  */
+object MigrateChangeLogEntry {
+
+  private[this] def migrateChangeLog(version: ChangeLogVersion, changeLogEntry: ChangeLogEntry, migration: MigrationV1): Either[String, ChangeLogEntry] =
+    // Do nothing
+    version match {
+      case ChangeLogVersion.V1 =>
+        // Already at expected version
+        Right(changeLogEntry)
+      case ChangeLogVersion.V2 =>
+        // No migration needed, preserve version
+        Right(changeLogEntry)
+      case ChangeLogVersion.V3 =>
+        if (changeLogEntry.legacyIdentifier != -1) {
+          Right(changeLogEntry)
+        } else {
+          Left(s"Unable to migrate from V3 to V1 directly")
+        }
+    }
+
+  private[this] def migrateChangeLog(version: ChangeLogVersion,changeLogEntry: ChangeLogEntry, migration: MigrationV2): Either[String, ChangeLogEntry] =
+    version match {
+      case ChangeLogVersion.V1 =>
+        // Migrate from version 1 to 2
+        Right(changeLogEntry.copy(
+          migrationId = Some(migration.identifier.id)))
+      case ChangeLogVersion.V2 =>
+        // No migration needed, already expected version
+        Right(changeLogEntry)
+      case ChangeLogVersion.V3 =>
+        // Add new information, but preserve version,
+        // allowing further downgrade to V1
+        Right(changeLogEntry.copy(
+          legacyIdentifier = migration.legacyId.legacyId))
+    }
+
+  private[this] def migrateChangeLog(version: ChangeLogVersion, changeLogEntry: ChangeLogEntry, migration: MigrationV3): Either[String, ChangeLogEntry] =
+    version match {
+      case ChangeLogVersion.V1 =>
+        Left(s"Unable to migrate from V1 to V3 directly")
+      case ChangeLogVersion.V2 =>
+        // V3 only drops information of old id
+        Right(changeLogEntry)
+      case ChangeLogVersion.V3 =>
+        // No migration needed, already at expected version
+        Right(changeLogEntry)
+    }
+
+  def migrateChangeLogEntry(
+    version: ChangeLogVersion,
+    changeLogEntry: ChangeLogEntry,
+    migration: Migration
+  ): Either[String, ChangeLogEntry] =
+    migration match {
+      case v: MigrationV1 => migrateChangeLog(version, changeLogEntry, v)
+      case v: MigrationV2 => migrateChangeLog(version, changeLogEntry, v)
+      case v: MigrationV3 => migrateChangeLog(version, changeLogEntry, v)
+    }
+
+}

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/MigrationOrdering.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/MigrationOrdering.scala
@@ -1,0 +1,29 @@
+package dk.cwconsult.peregrin.core.impl
+
+import dk.cwconsult.peregrin.core.migrations.Migration
+import dk.cwconsult.peregrin.core.migrations.MigrationId.LegacyId
+
+object MigrationOrdering {
+
+  def orderByLegacyId(allMigrations: Vector[Migration]): Either[String, Vector[Migration]] = {
+    // Extract integer legacy id for ordering
+    val migrationsWithLegacyIds: Vector[Option[(LegacyId, Migration)]] =
+      allMigrations.map { m =>
+        m.legacyIdentifier.map { legacyId =>
+          (legacyId, m)
+        }
+      }
+    // Split migrations based on declaration of legacy ids
+    val (missingLegacyIds, hasLegacyIds) =
+      migrationsWithLegacyIds.partition(_.isEmpty)
+    // Sort the migrations, if all have a legacy id
+    if (missingLegacyIds.nonEmpty) {
+      Left(
+        "The following Migration(s) are lacking a legacy Integer-identifier: "+
+        missingLegacyIds.mkString(", "))
+    } else {
+      Right(hasLegacyIds.flatten.sortBy(_._1.legacyId).map(_._2))
+    }
+  }
+
+}

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/dao/BaseDAO.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/dao/BaseDAO.scala
@@ -1,0 +1,66 @@
+package dk.cwconsult.peregrin.core.impl.dao
+
+import java.sql.Connection
+
+import dk.cwconsult.peregrin.core.Table
+import dk.cwconsult.peregrin.core.impl.ConnectionImplicits._
+import dk.cwconsult.peregrin.core.impl.dao.BaseDAO.ColumnProbe
+import dk.cwconsult.peregrin.core.impl.dao.BaseDAO.ColumnProbe.Exists
+import dk.cwconsult.peregrin.core.impl.dao.BaseDAO.ColumnProbe.Missing
+
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+abstract class BaseDAO(connection: Connection) {
+
+  /**
+    * Probe a given table for available columns, and process a handler,
+    * if the column either exists or is missing, according to the configuration.
+    */
+  protected[this] def probeAndMigrateTable(t: Table)(columnProbes: (ColumnProbe, () => Unit)*): Unit = {
+    // Resolve which probe handlers we need to process
+    val pendingProbeActions: Seq[(ColumnProbe, () => Unit)] =
+      connection.executeQuery(s"SELECT * FROM $t LIMIT 1") { resultSet =>
+        // Process the provided probes, and collect actions to be performed afterwarsd
+        columnProbes.flatMap { probe =>
+          val probeResult = Try(resultSet.findColumn(probe._1.columnName))
+          (probe._1, probeResult) match {
+            case (Exists(_), Success(_)) => Some(probe)
+            case (Exists(_), Failure(_)) => None
+            case (Missing(_), Success(_)) => None
+            case (Missing(_), Failure(_)) => Some(probe)
+          }
+        }
+      }
+    // Run matching handlers
+    pendingProbeActions.foreach { probe =>
+      probe._2()
+    }
+  }
+
+}
+
+object BaseDAO {
+
+  sealed trait ColumnProbe {
+    def columnName: String
+
+    def ->(f: => Unit): (ColumnProbe, () => Unit) =
+      (this, { () => f })
+  }
+
+  object ColumnProbe {
+
+    case class Exists private[dao] (
+      override val columnName: String)
+      extends ColumnProbe
+
+    case class Missing private[dao] (
+      override val columnName: String)
+      extends ColumnProbe
+
+  }
+
+
+}

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/dao/ChangeLogDAO.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/dao/ChangeLogDAO.scala
@@ -1,0 +1,34 @@
+package dk.cwconsult.peregrin.core.impl.dao
+
+import dk.cwconsult.peregrin.core.impl.ChangeLogEntry
+
+trait ChangeLogDAO {
+
+  /**
+    * Create ChangeLog table, if missing.
+    */
+  def createChangeLogIfMissing(): Unit
+
+  /**
+    * Read a changelog.
+    */
+  def readChangeLogEntries(): Vector[ChangeLogEntry]
+
+  /**
+    * Create a new Change Log Entry in the changelog table
+    */
+  def insertChangeLogEntry(changeLogEntry: ChangeLogEntry): Unit
+
+  /**
+    * Migrate an existing Change Log entry
+    */
+  def updateChangeLogEntry(
+    updatedChangeLogEntry: ChangeLogEntry,
+    oldChangeLogEntry: ChangeLogEntry): Unit
+
+  /**
+    * Run the given block in with a (transactional) lock.
+    */
+  def withChangeLogLock[A](block: => A): A
+
+}

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/dao/ChangeLogDAOImpl.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/dao/ChangeLogDAOImpl.scala
@@ -1,0 +1,144 @@
+package dk.cwconsult.peregrin.core.impl.dao
+
+import java.sql.Connection
+import java.util.UUID
+
+import dk.cwconsult.peregrin.core.Schema
+import dk.cwconsult.peregrin.core.Table
+import dk.cwconsult.peregrin.core.impl.ChangeLogEntry
+import dk.cwconsult.peregrin.core.impl.dao.BaseDAO.ColumnProbe.Missing
+
+import scala.collection.mutable.ArrayBuffer
+
+class ChangeLogDAOImpl(schema: Schema, connection: Connection)
+  extends BaseDAO(connection)
+    with ChangeLogDAO {
+
+  import dk.cwconsult.peregrin.core.impl.ConnectionImplicits._
+
+  private[this] val changeLogTable =
+    Table(
+      name = "__peregrin_changelog__",
+      schema)
+
+  private[this] val createPeregrinSchema: String =
+    s"CREATE SCHEMA IF NOT EXISTS $schema"
+
+  private[this] val createPeregrinChangeLogTable: String =
+    s"""
+        CREATE TABLE IF NOT EXISTS $changeLogTable (
+          "identifier" INT NOT NULL,
+          "sql" TEXT NOT NULL,
+          "executed" TIMESTAMP WITH TIME ZONE NOT NULL)
+      """.stripMargin
+
+  private[this] val alterPeregrinChangeLogTableAddUUIDId: String =
+    s"""
+        ALTER TABLE $changeLogTable
+        ADD COLUMN "migration_id" UUID
+     """.stripMargin
+
+  /**
+    * Create change log if necessary.
+    */
+  override def createChangeLogIfMissing(): Unit = {
+    // Create the schema if necessary.
+    connection.execute(createPeregrinSchema)
+    // Create the migration log table.
+    val _ = connection.execute(createPeregrinChangeLogTable)
+    // Migrate the schema, based on which columns we have available
+    probeAndMigrateTable(changeLogTable)(
+      // Add new UUID identifier for migration, if it doesn't exist already
+      Missing("migration_id") -> {
+        connection.execute(alterPeregrinChangeLogTableAddUUIDId)
+      })
+  }
+
+  // ---------------------------------------------
+
+  private[this] val selectChangeLogEntries: String =
+    s"""
+        SELECT "identifier", "migration_id", "sql"
+        FROM $changeLogTable
+        ORDER BY "identifier" ASC
+    """.stripMargin
+
+  override def readChangeLogEntries(): Vector[ChangeLogEntry] = {
+    connection.executeQuery(selectChangeLogEntries) { resultSet =>
+      // Extract all the results
+      val rows = new ArrayBuffer[ChangeLogEntry]()
+      while (resultSet.next()) {
+        // Build new changelog entry
+        rows += ChangeLogEntry(
+          legacyIdentifier = resultSet.getInt(1),
+          migrationId = Option(resultSet.getString(2)).map(UUID.fromString),
+          sql = resultSet.getString(3))
+      }
+      rows.toVector
+    }
+  }
+
+  // ---------------------------------------------
+
+  private[this] val insertChangeLogEntry: String =
+    s"""INSERT INTO $changeLogTable (
+       "identifier", "sql", "migration_id", "executed")
+       VALUES (?, ?, ?, now())""".stripMargin
+
+  def insertChangeLogEntry(changeLogEntry: ChangeLogEntry): Unit = {
+    // Insert the entry.
+    val insertCount = connection.executeUpdatePrepared(insertChangeLogEntry) { stmt =>
+      stmt.setInt(1, changeLogEntry.legacyIdentifier)
+      stmt.setString(2, changeLogEntry.sql)
+      stmt.setObject(3, changeLogEntry.migrationId.orNull)
+    }
+    // Sanity check: Must have inserted exactly one row.
+    if (insertCount != 1) {
+      throw new IllegalStateException(s"Internal consistency error: No rows inserted")
+    }
+  }
+
+  // ---------------------------------------------
+
+  private[this] val updateChangeLogEntry: String =
+    s"""UPDATE $changeLogTable SET
+       "identifier" = ?,
+       "migration_id" = ?,
+       "sql" = ?
+       WHERE
+       "identifier" = ? AND
+       "migration_id" IS NOT DISTINCT FROM ?
+       """.stripMargin
+
+  override def updateChangeLogEntry(updatedChangeLogEntry: ChangeLogEntry, oldChangeLogEntry: ChangeLogEntry): Unit = {
+    // update the entry.
+    val updateCount = connection.executeUpdatePrepared(updateChangeLogEntry) { stmt =>
+      stmt.setObject(1, updatedChangeLogEntry.legacyIdentifier)
+      stmt.setObject(2, updatedChangeLogEntry.migrationId.orNull)
+      stmt.setString(3, updatedChangeLogEntry.sql)
+      // Params
+      stmt.setInt(4, oldChangeLogEntry.legacyIdentifier)
+      stmt.setObject(5, oldChangeLogEntry.migrationId.orNull)
+    }
+    // Sanity check: Must have updated exactly one row.
+    if (updateCount != 1) {
+      throw new IllegalStateException(s"Internal consistency error: $updateCount rows updated")
+    }
+  }
+
+  // ---------------------------------------------
+
+  private[this] val lockChangeLogTable: String =
+    s"LOCK $changeLogTable IN EXCLUSIVE MODE"
+
+  override def withChangeLogLock[A](block: => A): A = {
+    connection.execute(lockChangeLogTable)
+    try {
+      block
+    } finally {
+      // Nothing to do; the lock will automatically be released at the end
+      // of the transaction.
+    }
+  }
+
+}

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/dao/ChangeLogMetaDataDAO.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/dao/ChangeLogMetaDataDAO.scala
@@ -1,0 +1,22 @@
+package dk.cwconsult.peregrin.core.impl.dao
+
+import dk.cwconsult.peregrin.core.impl.ChangeLogEntry.ChangeLogVersion
+
+trait ChangeLogMetaDataDAO {
+
+  /**
+    * Create ChangeLogMetaData table if missing
+    */
+  def createChangeLogMetaDataIfMissing(): Unit
+
+  /**
+    * Record a new Change Log format version in the metadata table
+    */
+  def writeChangeLogVersion(changeLogVersion: ChangeLogVersion): Unit
+
+  /**
+    * Query metadata table for format version
+    */
+  def readChangeLogVersionOrDefault(): ChangeLogVersion
+
+}

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/dao/ChangeLogMetaDataDAOImpl.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/impl/dao/ChangeLogMetaDataDAOImpl.scala
@@ -1,0 +1,126 @@
+package dk.cwconsult.peregrin.core.impl.dao
+
+import java.sql.Connection
+
+import dk.cwconsult.peregrin.core.InvalidChangeLogVersionException
+import dk.cwconsult.peregrin.core.Schema
+import dk.cwconsult.peregrin.core.Table
+import dk.cwconsult.peregrin.core.impl.ChangeLogEntry.ChangeLogVersion
+import dk.cwconsult.peregrin.core.impl.dao.BaseDAO.ColumnProbe.Missing
+import dk.cwconsult.peregrin.core.impl.dao.ChangeLogMetaDataDAOImpl.MetaData
+
+import scala.util.Try
+
+class ChangeLogMetaDataDAOImpl(schema: Schema, connection: Connection)
+  extends BaseDAO(connection)
+    with ChangeLogMetaDataDAO {
+
+  import dk.cwconsult.peregrin.core.impl.ConnectionImplicits._
+
+  private[this] val metaDataTable =
+    Table(
+      name = "__peregrin_metadata__",
+      schema)
+
+  private[this] val VERSION_IDENTIFIER: String = "version"
+  private[this] val VERSION_DEFAULT_VAL: ChangeLogVersion = ChangeLogVersion.V1
+
+  private[this] val createPeregrinMetaDataTable: String =
+    s"""
+        CREATE TABLE IF NOT EXISTS $metaDataTable (
+          "identifier" VARCHAR(255) NOT NULL,
+          "value" TEXT NOT NULL)
+      """.stripMargin
+
+
+  private[this] val lockPeregrinMetaDataTable: String =
+    s"LOCK $metaDataTable IN EXCLUSIVE MODE"
+
+  /**
+    * Create meta data table if necessary.
+    */
+  override def createChangeLogMetaDataIfMissing(): Unit = {
+    // Create the migration log table.
+    connection.execute(createPeregrinMetaDataTable)
+    // Lock the table while we inspect the entries (actually until end of transaction)
+    connection.execute(lockPeregrinMetaDataTable)
+    // Determine if we need to create a version entry
+    if (readChangeLogVersion().isEmpty) {
+      // Default to version 1
+      writeChangeLogVersion(VERSION_DEFAULT_VAL)
+    }
+  }
+
+  // ----------------------------------------
+
+  private[this] def readChangeLogVersion(): Option[ChangeLogVersion] =
+    readMetaDataByName(VERSION_IDENTIFIER)
+      .flatMap(_.asInt)
+      .map {
+        case ChangeLogVersion.V1.versionInt => ChangeLogVersion.V1
+        case ChangeLogVersion.V2.versionInt => ChangeLogVersion.V2
+        case ChangeLogVersion.V3.versionInt => ChangeLogVersion.V3
+        case other => throw new InvalidChangeLogVersionException(
+          s"Invalid version in changelog entry: $other")
+      }
+
+  override def readChangeLogVersionOrDefault(): ChangeLogVersion =
+    readChangeLogVersion().getOrElse(VERSION_DEFAULT_VAL)
+
+  override def writeChangeLogVersion(changeLogVersion: ChangeLogVersion): Unit =
+    writeMetaDataValue(VERSION_IDENTIFIER, changeLogVersion.versionInt.toString)
+
+  // ----------------------------------------
+
+  private[this] val selectMetaDataIdentifierValue: String =
+    s"""
+       SELECT "identifier", "value" FROM $metaDataTable
+       WHERE "identifier" = ?
+     """.stripMargin
+
+  private[this] def readMetaDataByName(identifier: String): Option[MetaData] =
+    connection.executeQueryPrepared(selectMetaDataIdentifierValue) { stmt =>
+      stmt.setString(1, identifier)
+    } { resultSet =>
+      Iterator
+        .continually(resultSet.next())
+        .takeWhile(identity)
+        .flatMap(_ => Option(resultSet.getString(2)))
+        .map(MetaData)
+        .toVector
+        .headOption
+    }
+
+  // ----------------------------------------
+
+  private[this] val insertMetaDataEntry: String =
+    s"""INSERT INTO $metaDataTable ("value", "identifier") VALUES (?, ?)"""
+
+  private[this] val updateMetaDataEntry: String =
+    s"""UPDATE $metaDataTable SET "value" = ? WHERE "identifier" = ?"""
+
+  private[this] def writeMetaDataValue(identifier: String, value: String): Unit = {
+    // Determine if we need to do an update or insert
+    val upsertQuery = readMetaDataByName(identifier) match {
+      case Some(_) => updateMetaDataEntry
+      case None => insertMetaDataEntry
+    }
+    // Perform the UPSERT
+    connection.executeUpdatePrepared(upsertQuery) { stmt =>
+      // The ordering of parameters is identical for both INSERT and UPDATE query
+      stmt.setString(1, value)
+      stmt.setString(2, identifier)
+    }
+  }
+
+}
+
+object ChangeLogMetaDataDAOImpl {
+
+  case class MetaData private[ChangeLogMetaDataDAOImpl] (value: String) {
+    def asInt: Option[Int] = Try(value.toInt).toOption
+  }
+
+}
+
+

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/migrations/Migration.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/migrations/Migration.scala
@@ -1,0 +1,63 @@
+package dk.cwconsult.peregrin.core.migrations
+
+import java.util.UUID
+
+import dk.cwconsult.peregrin.core.migrations.MigrationId.LegacyId
+import dk.cwconsult.peregrin.core.migrations.MigrationId.UniqueIdentifier
+
+/**
+ * Migration step.
+ */
+sealed trait Migration {
+
+  def identifier: MigrationId
+
+  def legacyIdentifier: Option[LegacyId]
+
+  def sql: String
+
+}
+
+object Migration {
+
+  case class MigrationV1(
+    override val identifier: LegacyId,
+    override val sql: String) extends Migration {
+    override val legacyIdentifier: Option[LegacyId] = Some(identifier)
+  }
+
+  case class MigrationV2(
+    legacyId: LegacyId,
+    override val identifier: UniqueIdentifier,
+    override val sql: String) extends Migration {
+    override val legacyIdentifier: Option[LegacyId] = Some(legacyId)
+  }
+
+  case class MigrationV3(
+    override val identifier: UniqueIdentifier,
+    override val sql: String) extends Migration {
+    override val legacyIdentifier: Option[LegacyId] = None
+  }
+
+  def apply(identifier: Int, sql: String): Migration =
+    MigrationV1(
+      identifier = LegacyId(identifier),
+      sql = sql)
+
+  def apply(uuid: String, sql: String): Migration =
+    apply(UUID.fromString(uuid), sql)
+
+  def apply(uuid: UUID, sql: String): Migration =
+    MigrationV3(
+      identifier = MigrationId.UniqueIdentifier(
+        id = uuid),
+      sql = sql)
+
+  def apply(legacyIdentifier: Int, uuid: UUID, sql: String): Migration =
+    MigrationV2(
+      legacyId = LegacyId(legacyIdentifier),
+      identifier = MigrationId.UniqueIdentifier(
+        id = uuid),
+      sql = sql)
+
+}

--- a/modules/core/src/main/scala/dk/cwconsult/peregrin/core/migrations/MigrationId.scala
+++ b/modules/core/src/main/scala/dk/cwconsult/peregrin/core/migrations/MigrationId.scala
@@ -1,0 +1,17 @@
+package dk.cwconsult.peregrin.core.migrations
+
+import java.util.UUID
+
+sealed trait MigrationId
+
+object MigrationId {
+
+  case class LegacyId(
+    legacyId: Int)
+    extends MigrationId
+
+  case class UniqueIdentifier(
+    id: UUID)
+    extends MigrationId
+
+}

--- a/modules/core/src/test/scala/dk/cwconsult/peregrin/core/impl/MigrateChangeLogSpec.scala
+++ b/modules/core/src/test/scala/dk/cwconsult/peregrin/core/impl/MigrateChangeLogSpec.scala
@@ -1,0 +1,291 @@
+package dk.cwconsult.peregrin.core.impl
+
+import java.util.UUID
+
+import dk.cwconsult.peregrin.core.InvalidMigrationSequenceException
+import dk.cwconsult.peregrin.core.Schema
+import dk.cwconsult.peregrin.core.Table
+import dk.cwconsult.peregrin.core.UnresolvedChangeLogEntriesFoundException
+import dk.cwconsult.peregrin.core.{migrations => internal}
+import dk.cwconsult.peregrin.core.Migration
+import dk.cwconsult.peregrin.core.test.Fixture
+import org.scalatest.WordSpec
+
+class MigrateChangeLogSpec extends WordSpec {
+
+  private[this] val migrationId0 = UUID.randomUUID()
+
+  for (schema <- Vector(Schema.Public, Schema.Named(UUID.randomUUID.toString))) {
+
+    "Migration.applyMigrations method" when {
+      s"applied to schema $schema" should {
+
+        "be compatible with original schema layout" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Setup: Create schema, may already exists, i.e. public
+            session.execute(
+                s"CREATE SCHEMA IF NOT EXISTS $schema")
+
+            // Setup: Create changelog table.
+            // We differ slightly from the original sql, by dropping the
+            // "if not exists", we woul like our test to fail, if we suddenly
+            // start having one from the start
+            val changeLogTable =
+              Table(
+                name = "__peregrin_changelog__",
+                schema)
+            session.execute(
+              s"""
+                 CREATE TABLE $changeLogTable (
+                  "identifier" INT NOT NULL,
+                  "sql" TEXT NOT NULL,
+                  "executed" TIMESTAMP WITH TIME ZONE NOT NULL)
+              """.stripMargin)
+
+            // Setup: Insert a changelog entry
+            val rowsInserted =
+              session.executeUpdate(
+                s"""
+                   INSERT INTO $changeLogTable
+                   ("identifier","sql","executed")
+                   VALUES
+                   (?, ?, now())
+                 """.stripMargin,
+                0,
+                createXSql)
+            assert(rowsInserted === 1)
+
+            // Setup: Create the actual X table
+            session.execute(createXSql)
+            assertCanSelectFromX()
+
+            // Exercise: Skip X, but create Y
+            migrate(Seq(
+              Migration(0, createXSql),
+              Migration(1, createYSql)))
+
+            // Verify
+            assertCanSelectFromXY()
+          }
+        }
+
+        "allow migration of an empty sequence" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Exercise
+            migrate(Seq.empty)
+            // Verify: no change logs
+            assert(readMigrations().isEmpty)
+          }
+        }
+
+        "fail if attempting to migrate empty sequence, after having done migrations before" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Setup: Create a migration
+            migrate(Seq(
+              Migration(0, createXSql)))
+            // Exercise:
+            val exception = intercept[UnresolvedChangeLogEntriesFoundException] {
+              migrate(Seq.empty)
+            }
+            assert(exception.getMessage.contains("MUST include all known change log entries"))
+          }
+        }
+
+        "throws an exception if a migration is missing a legacy id, if provided for one" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Exercise
+            val exception = intercept[InvalidMigrationSequenceException] {
+              migrate(Vector(
+                internal.Migration(0, createXSql),
+                internal.Migration(migrationId0, createYSql)))
+            }
+            // Verify
+            assert(exception.getMessage.contains("MUST have a common identifier type defined"))
+          }
+        }
+
+        "throws an exception if a migration is missing a UUID relation, if provided for one" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Exercise
+            val exception = intercept[InvalidMigrationSequenceException] {
+              migrate(Vector(
+                internal.Migration(0, createXSql),
+                internal.Migration(1, migrationId0, createYSql)))
+            }
+            // Verify
+            assert(exception.getMessage.contains("All migrations MUST be of the same version"))
+          }
+        }
+
+        "migrate changelog V1 entries to V2" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Setup: Prepare changelog db with a V1 entry
+            migrate(Seq(
+              Migration(0, createXSql)))
+
+            // Setup: Verify DB contains V1 entry
+            val v1Migrations = readMigrations()
+            assert(v1Migrations.nonEmpty)
+            assert(v1Migrations.head.legacyId === 0)
+            assert(v1Migrations.head.migrationId === None)
+            assertChangeLogVersionIs(1)
+
+            // Setup: Verify existence of X
+            assertCanSelectFromX()
+
+            // Exercise: Migrate change log entry to V2 format
+            migrate(Vector(
+              Migration(0, migrationId0, createXSql)))
+
+            // Verify
+            val migrations = readMigrations()
+            assert(migrations.length === 1)
+            assert(migrations.head.legacyId === 0)
+            assert(migrations.head.migrationId === Some(migrationId0))
+            assertChangeLogVersionIs(2)
+
+          }
+        }
+
+        "migrate changelog V2 entries to V3" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Setup: Prepare changelog db with a V3 entry
+            migrate(Vector(
+              Migration(0, migrationId0, createXSql)))
+
+            // Setup: Verify DB contains V2 entry
+            val v1Migrations = readMigrations()
+            assert(v1Migrations.length === 1)
+            assert(v1Migrations.head.legacyId === 0)
+            assert(v1Migrations.head.migrationId === Some(migrationId0))
+            assertChangeLogVersionIs(2)
+
+            // Setup: Verify existence of X
+            assertCanSelectFromX()
+
+            // Exercise: Migrate change log entry to V3 format
+            migrate(Vector(
+              Migration(migrationId0, createXSql)))
+
+            // Setup: Verify DB contains V2 entry
+            val migrations = readMigrations()
+            assert(migrations.length === 1)
+            assert(migrations.head.legacyId === 0)
+            assert(migrations.head.migrationId === Some(migrationId0))
+            assertChangeLogVersionIs(3)
+
+          }
+        }
+
+        "migrate changelog V1 entries to V2 and V3" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Setup: Prepare changelog db with a V1 entry
+            migrate(Seq(
+              Migration(0, createXSql)))
+
+            // Setup: Verify DB contains V1 entry
+            val v1Migrations = readMigrations()
+            assert(v1Migrations.nonEmpty)
+            assert(v1Migrations.head.legacyId === 0)
+            assert(v1Migrations.head.migrationId === None)
+            assertChangeLogVersionIs(1)
+
+            // Setup: Verify existence of X
+            assertCanSelectFromX()
+
+            // Exercise: Migrate change log entry to V2 format
+            migrate(Vector(
+              Migration(0, migrationId0, createXSql)))
+
+            // Verify migration to V2
+            val v2Migrations = readMigrations()
+            assert(v2Migrations.length === 1)
+            assert(v2Migrations.head.legacyId === 0)
+            assert(v2Migrations.head.migrationId === Some(migrationId0))
+            assertChangeLogVersionIs(2)
+
+            // Exercise: Migrate change log entry to V3 format
+            migrate(Vector(
+              Migration(migrationId0, createXSql)))
+
+            // Setup: Verify DB contains V3 entry
+            val migrations = readMigrations()
+            assert(migrations.length === 1)
+            assert(migrations.head.legacyId === 0)
+            assert(migrations.head.migrationId === Some(migrationId0))
+            assertChangeLogVersionIs(3)
+          }
+        }
+
+        "abort migration from changelog V1 entries directly to V3" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Setup: Prepare changelog db with a V1 entry
+            migrate(Seq(
+              Migration(0, createXSql)))
+
+            // Setup: Verify DB contains V1 entry
+            val v1Migrations = readMigrations()
+            assert(v1Migrations.nonEmpty)
+            assert(v1Migrations.head.legacyId === 0)
+            assert(v1Migrations.head.migrationId === None)
+            assertChangeLogVersionIs(1)
+
+            // Setup: Verify existence of X
+            assertCanSelectFromX()
+
+            // Exercise: Attempt to migrate directly to V3 format
+            val exception = intercept[UnresolvedChangeLogEntriesFoundException] {
+              migrate(Vector(
+                Migration(migrationId0, createXSql)))
+            }
+            assert(exception.getMessage.contains("MUST include all known change log entries"))
+          }
+        }
+
+        "migrate changelog V3 entries to V2 and V1" in new Fixture(schema) {
+          withTransaction { implicit session =>
+            // Setup: Prepare changelog db with a V3 entry
+            migrate(Vector(
+              Migration(migrationId0, createXSql)))
+
+            // Setup: Verify DB contains V3 entry
+            val v3Migrations = readMigrations()
+            assert(v3Migrations.nonEmpty)
+            assert(v3Migrations.head.legacyId === -1)
+            assert(v3Migrations.head.migrationId === Some(migrationId0))
+            assertChangeLogVersionIs(3)
+
+            // Setup: Verify existence of X
+            assertCanSelectFromX()
+
+            // Exercise: Migrate change log entry to V2 format
+            migrate(Vector(
+              Migration(0, migrationId0, createXSql)))
+
+            // Verify migration to V2
+            val v2Migrations = readMigrations()
+            assert(v2Migrations.length === 1)
+            assert(v2Migrations.head.legacyId === 0)
+            assert(v2Migrations.head.migrationId === Some(migrationId0))
+            assertChangeLogVersionIs(3)
+
+            // Exercise: Migrate change log entry to V1 format
+            migrate(Seq(
+              Migration(0, createXSql)))
+
+            // Verify: Verify DB contains V3 entry with V1 info
+            val migrations = readMigrations()
+            assert(migrations.length === 1)
+            assert(migrations.head.legacyId === 0)
+            assert(migrations.head.migrationId === Some(migrationId0))
+            assertChangeLogVersionIs(3)
+          }
+        }
+
+
+      }
+    }
+
+  }
+
+}

--- a/modules/core/src/test/scala/dk/cwconsult/peregrin/core/test/Fixture.scala
+++ b/modules/core/src/test/scala/dk/cwconsult/peregrin/core/test/Fixture.scala
@@ -1,0 +1,108 @@
+package dk.cwconsult.peregrin.core.test
+
+import java.util.UUID
+
+import dk.cwconsult.peregrin.core.Migrations
+import dk.cwconsult.peregrin.core.Schema
+import dk.cwconsult.peregrin.core.Table
+import dk.cwconsult.peregrin.core.{migrations => internal}
+import dk.cwconsult.peregrin.core.Migration
+import org.scalatest.Assertion
+import org.scalatest.Assertions
+import scalikejdbc.ConnectionPool
+import scalikejdbc.DB
+import scalikejdbc.DBSession
+import scalikejdbc.LoanPattern
+
+/**
+ * Fixture for running the tests.
+ */
+class Fixture(schema: Schema) {
+
+  val connectionPool: ConnectionPool =
+    TempgresConnection.createConnectionPool()
+
+  val createXSql: String = "CREATE TABLE X (A INT)"
+  val createYSql: String = "CREATE TABLE Y (B INT)"
+  val createXSqlBad: String = "CREATE TABLE X (Y CHAR(1))"
+  def createTableSql(table: String): String = s"CREATE TABLE $table (X INT)"
+
+  val peregrinChangeLogTable: Table =
+    Table("__peregrin_changelog__", schema)
+
+  val peregrinMetaDataTable: Table =
+    Table("__peregrin_metadata__", schema)
+
+  def assertCanQuery(sql  : String)(implicit dbSession: DBSession): Assertion = {
+    // Force a query; we are relying on the "list" function being strict here.
+    dbSession.list[Unit](sql)(rs => ())
+    // If we didn't have an exception, then we are certain that the relevant
+    // change sets were applied.
+    Assertions.succeed
+  }
+
+  case class ChangeLogEntry(
+    legacyId: Int,
+    sql: String,
+    migrationId: Option[UUID]
+  )
+
+  def readMigrations()(implicit dbSession: DBSession): Seq[ChangeLogEntry] =
+    dbSession.list[ChangeLogEntry](
+      s"""
+         |  SELECT "identifier", "sql", "migration_id"
+         |    FROM $peregrinChangeLogTable
+         |ORDER BY "identifier" ASC
+         |""".stripMargin)(
+      rs => ChangeLogEntry(
+        rs.int(1),
+        rs.string(2),
+        rs.stringOpt(3).map(UUID.fromString)))
+
+  def readChangeLogVersion()(implicit dbSession: DBSession): Option[Int] =
+    dbSession.first(
+      s"""
+         SELECT "value" FROM $peregrinMetaDataTable WHERE "identifier" = ?
+       """.stripMargin,
+      "version")(rs =>
+        rs.int(1)
+      )
+
+  def assertCanSelectFromX()(implicit dbSession: DBSession): Assertion =
+    assertCanQuery("SELECT * FROM X")
+
+  def assertCanSelectFromP(p: Table)(implicit dbSession: DBSession): Assertion =
+    assertCanQuery(s"SELECT * FROM $p")
+
+  def assertCanSelectFrom(p: String)(implicit dbSession: DBSession): Assertion =
+    assertCanQuery(s"SELECT * FROM $p")
+
+  def assertCanSelectFromPP(p: Table)(implicit dbSession: DBSession): Assertion =
+    assertCanQuery(s"SELECT * FROM $p, $p")
+
+  def assertCanSelectFromXY()(implicit dbSession: DBSession): Assertion =
+    assertCanQuery("SELECT * FROM X, Y")
+
+  def assertChangeLogVersionIs(expectedVersion: Int)(implicit dbSession: DBSession): Assertion = {
+    import Assertions._
+    assert(readChangeLogVersion() === Some(expectedVersion))
+  }
+
+  def migrate(migrations: Seq[Migration])(implicit dbSession: DBSession): Unit = {
+    val _ = Migrations.applyMigrations(dbSession.connection, schema, migrations)
+  }
+
+  def migrate(migrations: Vector[internal.Migration])(implicit dbSession: DBSession): Unit = {
+    val _ = Migrations.applyMigrations(dbSession.connection, schema, migrations)
+  }
+
+  def withTransaction(f: DBSession => Assertion): Assertion = {
+    LoanPattern.using(connectionPool.borrow()) { connection =>
+      DB(connection).localTx { implicit session =>
+        f(session)
+      }
+    }
+  }
+
+}
+

--- a/modules/core/src/test/scala/dk/cwconsult/peregrin/core/test/TempgresConnection.scala
+++ b/modules/core/src/test/scala/dk/cwconsult/peregrin/core/test/TempgresConnection.scala
@@ -1,0 +1,42 @@
+package dk.cwconsult.peregrin.core.test
+
+import java.util.UUID
+
+import dk.cwconsult.tempgres.TempgresClient
+import scalikejdbc.ConnectionPool
+import scalikejdbc.GlobalSettings
+import scalikejdbc.LoggingSQLAndTimeSettings
+
+object TempgresConnection {
+
+  /**
+   * Create connection pool connected to a temporary database.
+   */
+  def createConnectionPool(): ConnectionPool = {
+    // Generate connection pool name which is unlikely to collide with anything.
+    // We use this as a way to catch mistakes where the wrong connection pool
+    // is being accessed. This also prevents conflicts with other tests which
+    // could run simultaneously.
+    val connectionPoolName: String =
+      UUID.randomUUID().toString
+
+    // Create the database and connection pool
+    val database =
+      TempgresClient.createTemporaryDatabase(System.getProperty("tempgres.url", "http://tempgres:8080"))
+
+    ConnectionPool.add(
+      connectionPoolName,
+      database.getUrl,
+      database.getCredentials.getUserName,
+      database.getCredentials.getPassword)
+
+    // Reduce log spam.
+    GlobalSettings.loggingSQLAndTime = LoggingSQLAndTimeSettings(
+      singleLineMode = true,
+      logLevel = 'trace)
+
+    // Return the connection pool
+    ConnectionPool.get(connectionPoolName)
+  }
+
+}


### PR DESCRIPTION
The requirement for contiguous, persistent integer id's
hinders the composability of multi-source migrations. This
commit introduces a UUID identifier for migrations, with
ordering now being as given, instead of the integer based.

This version is fully complatible with API and database
changelogs for older versions. Existing projects that wish
to move to the UUID identifier, will need to perform a
stepwise migration from format 1 over format 2 to 3, to
associate the new identifier with existing changelog entries
in running environments.

It is supported to migrate all the way *back* to version 1,
from version 3 (as long as it's over version 2), so rollback
to a previous version should generally be possible, depending
on the compatibility of the schema changes of the new version,
with the application logic of the previous version.

Binary compatibility with previous release has been preserved.
on the call interfacer, but not with the values contained of
the response type AppliedMigrations.